### PR TITLE
Unwrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ being called, or called more than once, as well as concurrent calls to
 Unfortunately this package is not perfect either. It's possible that it is
 still missing some interfaces provided by the go core (let me know if you find
 one), and it won't work for applications adding their own interfaces into the
-mix.
+mix. You can however use `httpsnoop.Unwrap(w)` to access the underlying
+`http.ResponseWriter` and type-assert the result to its other interfaces.
 
 However, hopefully the explanation above has sufficiently scared you of rolling
 your own solution to this problem. httpsnoop may still break your application,

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -204,12 +204,21 @@ func (b *Build) Tests() *Generator {
 		g.Printf("// combination %d/%d\n", i+1, combinations)
 		g.Printf("{\n")
 		g.Printf(`t.Log("%s")`+"\n", strings.Join(fields, ", "))
-		g.Printf("w := Wrap(struct{\n%s\n}{}, Hooks{})\n", strings.Join(fields, "\n"))
+		g.Printf("inner := struct{\n%s\n}{}\n", strings.Join(fields, "\n"))
+		g.Printf("w := Wrap(inner, Hooks{})\n")
 		for i, iface := range ifaces {
 			g.Printf("if _, ok := w.(%s); ok != %t {\n", iface.Name, expected[i])
 			g.Printf("t.Error(\"unexpected interface\");\n")
 			g.Printf("}\n")
 		}
+		g.Printf(`
+if w, ok := w.(Unwrapper); ok {
+  if w.Unwrap() != inner {
+    t.Error("w.Unwrap() failed")
+  }
+} else {
+	t.Error("Unwrapper interface not implemented")
+}`)
 		g.Printf("}\n")
 		g.Printf("\n")
 	}

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -167,6 +167,18 @@ type rw struct {
 			g.Printf("\n")
 		}
 	}
+	g.Printf(`
+// Unwrap returns the underlying http.ResponseWriter from within zero or more
+// layers of httpsnoop wrappers.
+func Unwrap(w http.ResponseWriter) http.ResponseWriter {
+	if rw, ok := w.(Unwrapper); ok {
+		// recurse until rw.Unwrap() returns a non-Unwrapper
+		return Unwrap(rw.Unwrap())
+	} else {
+		return w
+	}
+}
+`)
 	return &g
 }
 

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -70,6 +70,32 @@ type Hooks struct {
 	}
 	g.Printf("}\n")
 
+	g.Printf(`
+type Unwrapper interface {
+	Unwrap() http.ResponseWriter
+}
+`)
+
+	combinations := 1 << uint(len(subIfaces))
+	for i := 0; i < combinations; i++ {
+		fields := make([]string, 0, len(subIfaces))
+		fields = append(fields, "http.ResponseWriter")
+		for j, iface := range subIfaces {
+			ok := i&(1<<uint(len(subIfaces)-j-1)) > 0
+			if ok {
+				fields = append(fields, iface.Name)
+			}
+		}
+		g.Printf("// combination %d/%d\n", i+1, combinations)
+		g.Printf("type s%d struct{\n%s\n}\n", i, strings.Join(fields, "\n"))
+		g.Printf(`
+// Unwrap returns the underlying http.ResponseWriter
+func (s s%d) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+`, i)
+	}
+
 	// Wrap func
 	docList := make([]string, len(subIfaces))
 	for i, iface := range subIfaces {
@@ -94,28 +120,26 @@ type Hooks struct {
 		g.Printf("_, i%d := w.(%s)\n", i, iface.Name)
 	}
 	g.Printf("switch {\n")
-	combinations := 1 << uint(len(subIfaces))
 	for i := 0; i < combinations; i++ {
 		conditions := make([]string, len(subIfaces))
-		fields := make([]string, 0, len(subIfaces))
-		fields = append(fields, "http.ResponseWriter")
-		for j, iface := range subIfaces {
+		lenFields := 1 // http.ResponseWriter
+		for j, _ := range subIfaces {
 			ok := i&(1<<uint(len(subIfaces)-j-1)) > 0
 			if !ok {
 				conditions[j] = "!"
 			} else {
-				fields = append(fields, iface.Name)
+				lenFields++
 			}
 			conditions[j] += fmt.Sprintf("i%d", j)
 		}
-		values := make([]string, len(fields))
-		for i, _ := range fields {
+		values := make([]string, lenFields)
+		for i := 0; i < lenFields; i++ {
 			values[i] = "rw"
 		}
-		g.Printf("// combination %d/%d\n", i+1, combinations)
+		// g.Printf("// combination %d/%d\n", i+1, combinations)
 		g.Printf("case %s:\n", strings.Join(conditions, "&&"))
-		fieldsS, valuesS := strings.Join(fields, "\n"), strings.Join(values, ",")
-		g.Printf("return struct{\n%s\n}{%s}\n", fieldsS, valuesS)
+		valuesS := strings.Join(values, ",")
+		g.Printf("return s%d{%s}\n", i, valuesS)
 	}
 	g.Printf("}\n")
 	g.Printf("panic(\"unreachable\")")

--- a/unwrap_test.go
+++ b/unwrap_test.go
@@ -1,0 +1,27 @@
+package httpsnoop
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUnwrap(t *testing.T) {
+	w := Wrap(httptest.NewRecorder(), Hooks{})
+	if _, ok := Unwrap(w).(*httptest.ResponseRecorder); !ok {
+		t.Error("expected ResponseRecorder")
+	}
+}
+
+func TestUnwrapWithoutWrap(t *testing.T) {
+	w := httptest.NewRecorder()
+	if _, ok := Unwrap(w).(*httptest.ResponseRecorder); !ok {
+		t.Error("expected ResponseRecorder")
+	}
+}
+
+func TestUnwrapMultipleLayers(t *testing.T) {
+	w := Wrap(Wrap(httptest.NewRecorder(), Hooks{}), Hooks{})
+	if _, ok := Unwrap(w).(*httptest.ResponseRecorder); !ok {
+		t.Error("expected ResponseRecorder")
+	}
+}

--- a/wrap_generated_gteq_1.8.go
+++ b/wrap_generated_gteq_1.8.go
@@ -48,6 +48,410 @@ type Hooks struct {
 	Push        func(PushFunc) PushFunc
 }
 
+type Unwrapper interface {
+	Unwrap() http.ResponseWriter
+}
+
+// combination 1/32
+type s0 struct {
+	http.ResponseWriter
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s0) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 2/32
+type s1 struct {
+	http.ResponseWriter
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s1) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 3/32
+type s2 struct {
+	http.ResponseWriter
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s2) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 4/32
+type s3 struct {
+	http.ResponseWriter
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s3) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 5/32
+type s4 struct {
+	http.ResponseWriter
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s4) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 6/32
+type s5 struct {
+	http.ResponseWriter
+	http.Hijacker
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s5) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 7/32
+type s6 struct {
+	http.ResponseWriter
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s6) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 8/32
+type s7 struct {
+	http.ResponseWriter
+	http.Hijacker
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s7) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 9/32
+type s8 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s8) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 10/32
+type s9 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s9) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 11/32
+type s10 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s10) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 12/32
+type s11 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s11) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 13/32
+type s12 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s12) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 14/32
+type s13 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	http.Hijacker
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s13) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 15/32
+type s14 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s14) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 16/32
+type s15 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	http.Hijacker
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s15) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 17/32
+type s16 struct {
+	http.ResponseWriter
+	http.Flusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s16) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 18/32
+type s17 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s17) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 19/32
+type s18 struct {
+	http.ResponseWriter
+	http.Flusher
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s18) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 20/32
+type s19 struct {
+	http.ResponseWriter
+	http.Flusher
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s19) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 21/32
+type s20 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s20) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 22/32
+type s21 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Hijacker
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s21) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 23/32
+type s22 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s22) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 24/32
+type s23 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Hijacker
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s23) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 25/32
+type s24 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s24) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 26/32
+type s25 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s25) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 27/32
+type s26 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s26) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 28/32
+type s27 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s27) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 29/32
+type s28 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s28) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 30/32
+type s29 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	http.Hijacker
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s29) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 31/32
+type s30 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s30) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 32/32
+type s31 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	http.Hijacker
+	io.ReaderFrom
+	http.Pusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s31) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
 // Wrap returns a wrapped version of w that provides the exact same interface
 // as w. Specifically if w implements any combination of:
 //
@@ -71,246 +475,70 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 	_, i3 := w.(io.ReaderFrom)
 	_, i4 := w.(http.Pusher)
 	switch {
-	// combination 1/32
 	case !i0 && !i1 && !i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-		}{rw}
-	// combination 2/32
+		return s0{rw}
 	case !i0 && !i1 && !i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Pusher
-		}{rw, rw}
-	// combination 3/32
+		return s1{rw, rw}
 	case !i0 && !i1 && !i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			io.ReaderFrom
-		}{rw, rw}
-	// combination 4/32
+		return s2{rw, rw}
 	case !i0 && !i1 && !i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw}
-	// combination 5/32
+		return s3{rw, rw, rw}
 	case !i0 && !i1 && i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-		}{rw, rw}
-	// combination 6/32
+		return s4{rw, rw}
 	case !i0 && !i1 && i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			http.Pusher
-		}{rw, rw, rw}
-	// combination 7/32
+		return s5{rw, rw, rw}
 	case !i0 && !i1 && i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw}
-	// combination 8/32
+		return s6{rw, rw, rw}
 	case !i0 && !i1 && i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw, rw}
-	// combination 9/32
+		return s7{rw, rw, rw, rw}
 	case !i0 && i1 && !i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-		}{rw, rw}
-	// combination 10/32
+		return s8{rw, rw}
 	case !i0 && i1 && !i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			http.Pusher
-		}{rw, rw, rw}
-	// combination 11/32
+		return s9{rw, rw, rw}
 	case !i0 && i1 && !i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			io.ReaderFrom
-		}{rw, rw, rw}
-	// combination 12/32
+		return s10{rw, rw, rw}
 	case !i0 && i1 && !i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw, rw}
-	// combination 13/32
+		return s11{rw, rw, rw, rw}
 	case !i0 && i1 && i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			http.Hijacker
-		}{rw, rw, rw}
-	// combination 14/32
+		return s12{rw, rw, rw}
 	case !i0 && i1 && i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			http.Hijacker
-			http.Pusher
-		}{rw, rw, rw, rw}
-	// combination 15/32
+		return s13{rw, rw, rw, rw}
 	case !i0 && i1 && i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw, rw}
-	// combination 16/32
+		return s14{rw, rw, rw, rw}
 	case !i0 && i1 && i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			http.Hijacker
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw, rw, rw}
-	// combination 17/32
+		return s15{rw, rw, rw, rw, rw}
 	case i0 && !i1 && !i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-		}{rw, rw}
-	// combination 18/32
+		return s16{rw, rw}
 	case i0 && !i1 && !i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.Pusher
-		}{rw, rw, rw}
-	// combination 19/32
+		return s17{rw, rw, rw}
 	case i0 && !i1 && !i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			io.ReaderFrom
-		}{rw, rw, rw}
-	// combination 20/32
+		return s18{rw, rw, rw}
 	case i0 && !i1 && !i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw, rw}
-	// combination 21/32
+		return s19{rw, rw, rw, rw}
 	case i0 && !i1 && i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.Hijacker
-		}{rw, rw, rw}
-	// combination 22/32
+		return s20{rw, rw, rw}
 	case i0 && !i1 && i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.Hijacker
-			http.Pusher
-		}{rw, rw, rw, rw}
-	// combination 23/32
+		return s21{rw, rw, rw, rw}
 	case i0 && !i1 && i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw, rw}
-	// combination 24/32
+		return s22{rw, rw, rw, rw}
 	case i0 && !i1 && i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.Hijacker
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw, rw, rw}
-	// combination 25/32
+		return s23{rw, rw, rw, rw, rw}
 	case i0 && i1 && !i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-		}{rw, rw, rw}
-	// combination 26/32
+		return s24{rw, rw, rw}
 	case i0 && i1 && !i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			http.Pusher
-		}{rw, rw, rw, rw}
-	// combination 27/32
+		return s25{rw, rw, rw, rw}
 	case i0 && i1 && !i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			io.ReaderFrom
-		}{rw, rw, rw, rw}
-	// combination 28/32
+		return s26{rw, rw, rw, rw}
 	case i0 && i1 && !i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw, rw, rw}
-	// combination 29/32
+		return s27{rw, rw, rw, rw, rw}
 	case i0 && i1 && i2 && !i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			http.Hijacker
-		}{rw, rw, rw, rw}
-	// combination 30/32
+		return s28{rw, rw, rw, rw}
 	case i0 && i1 && i2 && !i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			http.Hijacker
-			http.Pusher
-		}{rw, rw, rw, rw, rw}
-	// combination 31/32
+		return s29{rw, rw, rw, rw, rw}
 	case i0 && i1 && i2 && i3 && !i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw, rw, rw}
-	// combination 32/32
+		return s30{rw, rw, rw, rw, rw}
 	case i0 && i1 && i2 && i3 && i4:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			http.Hijacker
-			io.ReaderFrom
-			http.Pusher
-		}{rw, rw, rw, rw, rw, rw}
+		return s31{rw, rw, rw, rw, rw, rw}
 	}
 	panic("unreachable")
 }

--- a/wrap_generated_gteq_1.8.go
+++ b/wrap_generated_gteq_1.8.go
@@ -611,3 +611,14 @@ func (w *rw) Push(target string, opts *http.PushOptions) error {
 	}
 	return f(target, opts)
 }
+
+// Unwrap returns the underlying http.ResponseWriter from within zero or more
+// layers of httpsnoop wrappers.
+func Unwrap(w http.ResponseWriter) http.ResponseWriter {
+	if rw, ok := w.(Unwrapper); ok {
+		// recurse until rw.Unwrap() returns a non-Unwrapper
+		return Unwrap(rw.Unwrap())
+	} else {
+		return w
+	}
+}

--- a/wrap_generated_gteq_1.8_test.go
+++ b/wrap_generated_gteq_1.8_test.go
@@ -13,9 +13,10 @@ func TestWrap(t *testing.T) {
 	// combination 1/32
 	{
 		t.Log("http.ResponseWriter")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -33,16 +34,25 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 2/32
 	{
 		t.Log("http.ResponseWriter, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -60,16 +70,25 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 3/32
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -87,17 +106,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 4/32
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -115,16 +143,25 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 5/32
 	{
 		t.Log("http.ResponseWriter, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -142,17 +179,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 6/32
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -170,17 +216,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 7/32
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -198,18 +253,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 8/32
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Hijacker
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -227,16 +291,25 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 9/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -254,17 +327,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 10/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -282,17 +364,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 11/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -310,18 +401,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 12/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -339,17 +439,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 13/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -367,18 +476,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 14/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -396,18 +514,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 15/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -425,19 +552,28 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 16/32
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -456,15 +592,24 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 17/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -482,17 +627,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 18/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -510,17 +664,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 19/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -538,18 +701,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 20/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -567,17 +739,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 21/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -595,18 +776,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 22/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -624,18 +814,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 23/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -653,19 +852,28 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 24/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -684,16 +892,25 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 25/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -711,18 +928,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 26/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -740,18 +966,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 27/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -769,19 +1004,28 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 28/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -800,17 +1044,26 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 29/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -828,19 +1081,28 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 30/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			http.Hijacker
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -859,18 +1121,27 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 31/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -889,19 +1160,28 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(http.Pusher); ok != false {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 32/32
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, http.Pusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
 			http.Pusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -919,6 +1199,14 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(http.Pusher); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 

--- a/wrap_generated_lt_1.8.go
+++ b/wrap_generated_lt_1.8.go
@@ -357,3 +357,14 @@ func (w *rw) ReadFrom(src io.Reader) (int64, error) {
 	}
 	return f(src)
 }
+
+// Unwrap returns the underlying http.ResponseWriter from within zero or more
+// layers of httpsnoop wrappers.
+func Unwrap(w http.ResponseWriter) http.ResponseWriter {
+	if rw, ok := w.(Unwrapper); ok {
+		// recurse until rw.Unwrap() returns a non-Unwrapper
+		return Unwrap(rw.Unwrap())
+	} else {
+		return w
+	}
+}

--- a/wrap_generated_lt_1.8.go
+++ b/wrap_generated_lt_1.8.go
@@ -44,6 +44,202 @@ type Hooks struct {
 	ReadFrom    func(ReadFromFunc) ReadFromFunc
 }
 
+type Unwrapper interface {
+	Unwrap() http.ResponseWriter
+}
+
+// combination 1/16
+type s0 struct {
+	http.ResponseWriter
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s0) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 2/16
+type s1 struct {
+	http.ResponseWriter
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s1) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 3/16
+type s2 struct {
+	http.ResponseWriter
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s2) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 4/16
+type s3 struct {
+	http.ResponseWriter
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s3) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 5/16
+type s4 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s4) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 6/16
+type s5 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s5) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 7/16
+type s6 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s6) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 8/16
+type s7 struct {
+	http.ResponseWriter
+	http.CloseNotifier
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s7) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 9/16
+type s8 struct {
+	http.ResponseWriter
+	http.Flusher
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s8) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 10/16
+type s9 struct {
+	http.ResponseWriter
+	http.Flusher
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s9) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 11/16
+type s10 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s10) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 12/16
+type s11 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s11) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 13/16
+type s12 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s12) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 14/16
+type s13 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s13) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 15/16
+type s14 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	http.Hijacker
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s14) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
+// combination 16/16
+type s15 struct {
+	http.ResponseWriter
+	http.Flusher
+	http.CloseNotifier
+	http.Hijacker
+	io.ReaderFrom
+}
+
+// Unwrap returns the underlying http.ResponseWriter
+func (s s15) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter.(*rw).w
+}
+
 // Wrap returns a wrapped version of w that provides the exact same interface
 // as w. Specifically if w implements any combination of:
 //
@@ -65,118 +261,38 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 	_, i2 := w.(http.Hijacker)
 	_, i3 := w.(io.ReaderFrom)
 	switch {
-	// combination 1/16
 	case !i0 && !i1 && !i2 && !i3:
-		return struct {
-			http.ResponseWriter
-		}{rw}
-	// combination 2/16
+		return s0{rw}
 	case !i0 && !i1 && !i2 && i3:
-		return struct {
-			http.ResponseWriter
-			io.ReaderFrom
-		}{rw, rw}
-	// combination 3/16
+		return s1{rw, rw}
 	case !i0 && !i1 && i2 && !i3:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-		}{rw, rw}
-	// combination 4/16
+		return s2{rw, rw}
 	case !i0 && !i1 && i2 && i3:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw}
-	// combination 5/16
+		return s3{rw, rw, rw}
 	case !i0 && i1 && !i2 && !i3:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-		}{rw, rw}
-	// combination 6/16
+		return s4{rw, rw}
 	case !i0 && i1 && !i2 && i3:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			io.ReaderFrom
-		}{rw, rw, rw}
-	// combination 7/16
+		return s5{rw, rw, rw}
 	case !i0 && i1 && i2 && !i3:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			http.Hijacker
-		}{rw, rw, rw}
-	// combination 8/16
+		return s6{rw, rw, rw}
 	case !i0 && i1 && i2 && i3:
-		return struct {
-			http.ResponseWriter
-			http.CloseNotifier
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw, rw}
-	// combination 9/16
+		return s7{rw, rw, rw, rw}
 	case i0 && !i1 && !i2 && !i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-		}{rw, rw}
-	// combination 10/16
+		return s8{rw, rw}
 	case i0 && !i1 && !i2 && i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			io.ReaderFrom
-		}{rw, rw, rw}
-	// combination 11/16
+		return s9{rw, rw, rw}
 	case i0 && !i1 && i2 && !i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.Hijacker
-		}{rw, rw, rw}
-	// combination 12/16
+		return s10{rw, rw, rw}
 	case i0 && !i1 && i2 && i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw, rw}
-	// combination 13/16
+		return s11{rw, rw, rw, rw}
 	case i0 && i1 && !i2 && !i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-		}{rw, rw, rw}
-	// combination 14/16
+		return s12{rw, rw, rw}
 	case i0 && i1 && !i2 && i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			io.ReaderFrom
-		}{rw, rw, rw, rw}
-	// combination 15/16
+		return s13{rw, rw, rw, rw}
 	case i0 && i1 && i2 && !i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			http.Hijacker
-		}{rw, rw, rw, rw}
-	// combination 16/16
+		return s14{rw, rw, rw, rw}
 	case i0 && i1 && i2 && i3:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			http.CloseNotifier
-			http.Hijacker
-			io.ReaderFrom
-		}{rw, rw, rw, rw, rw}
+		return s15{rw, rw, rw, rw, rw}
 	}
 	panic("unreachable")
 }

--- a/wrap_generated_lt_1.8_test.go
+++ b/wrap_generated_lt_1.8_test.go
@@ -13,9 +13,10 @@ func TestWrap(t *testing.T) {
 	// combination 1/16
 	{
 		t.Log("http.ResponseWriter")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -30,16 +31,25 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 2/16
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -54,16 +64,25 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 3/16
 	{
 		t.Log("http.ResponseWriter, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -78,17 +97,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 4/16
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -103,16 +131,25 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 5/16
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -127,17 +164,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 6/16
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -152,17 +198,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 7/16
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -177,18 +232,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 8/16
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -204,15 +268,24 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 9/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -227,17 +300,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 10/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -252,17 +334,26 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 11/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -277,18 +368,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 12/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -304,16 +404,25 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 13/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -328,18 +437,27 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 
 	// combination 14/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -355,17 +473,26 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 15/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			http.Hijacker
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -381,18 +508,27 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
 	}
 
 	// combination 16/16
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
-		w := Wrap(struct {
+		inner := struct {
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 			http.Hijacker
 			io.ReaderFrom
-		}{}, Hooks{})
+		}{}
+		w := Wrap(inner, Hooks{})
 		if _, ok := w.(http.ResponseWriter); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -407,6 +543,14 @@ func TestWrap(t *testing.T) {
 		}
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
 		}
 	}
 


### PR DESCRIPTION
Introduce `type Unwrapper interface { Unwrap() http.ResponseWriter }` and a recursive `func Unwrap` helper so that the underlying `http.ResponseWriter` can be accessed.

The `Unwrap()` method is tested against each possible return type, and the `Unwrap()` package function is tested with 0, 1 and 2 layers of wrapping.

Closes #8 — more background in that issue.

Concrete usage example (thanks @basvanbeek):

```go
if txn, ok := httpsnoop.Unwrap(w).(newrelic.Transaction); ok {
  txn.SetAttribute("foo", "bar")
}
```

This turned out to be harder than I thought to implement, because the generated code was returning inline/anonymous struct literals. I've lifted them out into named types (`s0`, `s1`, …) and added `Unwrap()` to each to fulfil the `Unwrapper` interface.

Let me know if the unanticipated complexity/change feels worth this functionality. (To me it is)

`func Unwrap` is the helper suggested in #8, and that's where the recursion lives to unwrap multiple layers of httpsnoop, which can happen in middleware stacks.