### PR TITLE
Allow specifying initial metrics

### DIFF
--- a/capture_metrics.go
+++ b/capture_metrics.go
@@ -35,9 +35,16 @@ func CaptureMetrics(hnd http.Handler, w http.ResponseWriter, r *http.Request) Me
 // sugar on top of this func), but is a more usable interface if your
 // application doesn't use the Go http.Handler interface.
 func CaptureMetricsFn(w http.ResponseWriter, fn func(http.ResponseWriter)) Metrics {
+	m := Metrics{Code: http.StatusOK}
+	m.CaptureMetrics(w, fn)
+	return m
+}
+
+// CaptureMetrics wraps w and calls fn with the wrapped w and updates
+// Metrics m with the resulting metrics.
+func (m *Metrics) CaptureMetrics(w http.ResponseWriter, fn func(http.ResponseWriter)) {
 	var (
 		start         = time.Now()
-		m             = Metrics{Code: http.StatusOK}
 		headerWritten bool
 		hooks         = Hooks{
 			WriteHeader: func(next WriteHeaderFunc) WriteHeaderFunc {
@@ -74,6 +81,5 @@ func CaptureMetricsFn(w http.ResponseWriter, fn func(http.ResponseWriter)) Metri
 	)
 
 	fn(Wrap(w, hooks))
-	m.Duration = time.Since(start)
-	return m
+	m.Duration += time.Since(start)
 }

--- a/capture_metrics.go
+++ b/capture_metrics.go
@@ -41,7 +41,8 @@ func CaptureMetricsFn(w http.ResponseWriter, fn func(http.ResponseWriter)) Metri
 }
 
 // CaptureMetrics wraps w and calls fn with the wrapped w and updates
-// Metrics m with the resulting metrics.
+// Metrics m with the resulting metrics. This is similar to CaptureMetricsFn,
+// but allows one to customize starting Metrics object.
 func (m *Metrics) CaptureMetrics(w http.ResponseWriter, fn func(http.ResponseWriter)) {
 	var (
 		start         = time.Now()


### PR DESCRIPTION
Fixes #17.

This preserves backwards compatibility and opens doors to other interesting use cases (where you can call `CaptureMetrics` multiple times, for example). I am not sure why would that be useful, but it looked like a nice generalization, allowing to specify initial values, not just status.