### PR TITLE
fix: populate duration when handler panics

### DIFF
--- a/capture_metrics.go
+++ b/capture_metrics.go
@@ -81,6 +81,7 @@ func (m *Metrics) CaptureMetrics(w http.ResponseWriter, fn func(http.ResponseWri
 		}
 	)
 
+	// defer to ensure duration is updated even if the handler panics
 	defer func() {
 		m.Duration += time.Since(start)
 	}()

--- a/capture_metrics.go
+++ b/capture_metrics.go
@@ -81,8 +81,10 @@ func (m *Metrics) CaptureMetrics(w http.ResponseWriter, fn func(http.ResponseWri
 		}
 	)
 
+	defer func() {
+		m.Duration += time.Since(start)
+	}()
 	fn(Wrap(w, hooks))
-	m.Duration += time.Since(start)
 }
 
 // deadliner defines two methods introduced in go 1.20. The standard library

--- a/capture_metrics_test.go
+++ b/capture_metrics_test.go
@@ -102,9 +102,9 @@ func TestCaptureMetrics(t *testing.T) {
 			if !errContains(err, test.WantErr) {
 				t.Errorf("test %d: got=%s want=%s", i, err, test.WantErr)
 			}
-			if res != nil && res.Body != nil {
+			if err == nil {
 				defer res.Body.Close()
-			}
+ 			}
 			m := <-ch
 			if m.Code != test.WantCode {
 				t.Errorf("test %d: got=%d want=%d", i, m.Code, test.WantCode)


### PR DESCRIPTION
If we use `defer` to fill `Duration`, it can be filled even when handler panics.

Also reworks tests to

- Set name for running tests individually
- Always return `Metrics` even if handler panics
- Always runs assertions
- Checks for nonzero duration for panic
- Checks status/code / bytes written for panic case. No logic change to this here but it's good coverage I think.