### PR TITLE
feat: Support FlushError method

### DIFF
--- a/capture_metrics.go
+++ b/capture_metrics.go
@@ -88,6 +88,13 @@ func (m *Metrics) CaptureMetrics(w http.ResponseWriter, fn func(http.ResponseWri
 	fn(Wrap(w, hooks))
 }
 
+// errorFlusher defines a method introduced in go 1.20. The standard
+// library seems not to provide an interface we can import, hence its definition
+// here.
+type errorFlusher interface {
+	FlushError() error
+}
+
 // deadliner defines two methods introduced in go 1.20. The standard library
 // seems not to provide an interface we can import, hence its definition here.
 type deadliner interface {

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -330,6 +330,12 @@ func main() {
 			},
 		},
 		{
+			Name: "errorFlusher", // Introduced in Go 1.20.
+			Funcs: []*InterfaceFunc{
+				{"FlushError", nil, "error"},
+			},
+		},
+		{
 			Name: "deadliner", // Introduced in Go 1.20.
 			Funcs: []*InterfaceFunc{
 				{"SetReadDeadline", FuncArgs{{"deadline", "time.Time"}}, "error"},

--- a/wrap_generated_gteq_1.8.go
+++ b/wrap_generated_gteq_1.8.go
@@ -34,6 +34,9 @@ type HijackFunc func() (net.Conn, *bufio.ReadWriter, error)
 // ReadFromFunc is part of the io.ReaderFrom interface.
 type ReadFromFunc func(src io.Reader) (int64, error)
 
+// FlushErrorFunc is part of the errorFlusher interface.
+type FlushErrorFunc func() error
+
 // SetReadDeadlineFunc is part of the deadliner interface.
 type SetReadDeadlineFunc func(deadline time.Time) error
 
@@ -57,6 +60,7 @@ type Hooks struct {
 	CloseNotify      func(CloseNotifyFunc) CloseNotifyFunc
 	Hijack           func(HijackFunc) HijackFunc
 	ReadFrom         func(ReadFromFunc) ReadFromFunc
+	FlushError       func(FlushErrorFunc) FlushErrorFunc
 	SetReadDeadline  func(SetReadDeadlineFunc) SetReadDeadlineFunc
 	SetWriteDeadline func(SetWriteDeadlineFunc) SetWriteDeadlineFunc
 	EnableFullDuplex func(EnableFullDuplexFunc) EnableFullDuplexFunc
@@ -70,6 +74,7 @@ type Hooks struct {
 // - http.CloseNotifier
 // - http.Hijacker
 // - io.ReaderFrom
+// - errorFlusher
 // - deadliner
 // - fullDuplexEnabler
 // - http.Pusher
@@ -86,63 +91,64 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 	_, i1 := w.(http.CloseNotifier)
 	_, i2 := w.(http.Hijacker)
 	_, i3 := w.(io.ReaderFrom)
-	_, i4 := w.(deadliner)
-	_, i5 := w.(fullDuplexEnabler)
-	_, i6 := w.(http.Pusher)
+	_, i4 := w.(errorFlusher)
+	_, i5 := w.(deadliner)
+	_, i6 := w.(fullDuplexEnabler)
+	_, i7 := w.(http.Pusher)
 	switch {
-	// combination 1/128
-	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 1/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 		}{rw, rw}
-	// combination 2/128
-	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6:
+	// combination 2/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Pusher
 		}{rw, rw, rw}
-	// combination 3/128
-	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6:
+	// combination 3/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			fullDuplexEnabler
 		}{rw, rw, rw}
-	// combination 4/128
-	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6:
+	// combination 4/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw}
-	// combination 5/128
-	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6:
+	// combination 5/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			deadliner
 		}{rw, rw, rw}
-	// combination 6/128
-	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6:
+	// combination 6/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw}
-	// combination 7/128
-	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6:
+	// combination 7/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 8/128
-	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && i6:
+	// combination 8/256
+	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -150,31 +156,99 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 9/128
-	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6:
+	// combination 9/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+		}{rw, rw, rw}
+	// combination 10/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw}
+	// combination 11/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw}
+	// combination 12/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw}
+	// combination 13/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw}
+	// combination 14/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw}
+	// combination 15/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 16/256
+	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 17/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			io.ReaderFrom
 		}{rw, rw, rw}
-	// combination 10/128
-	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6:
+	// combination 18/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw}
-	// combination 11/128
-	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6:
+	// combination 19/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 12/128
-	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && i6:
+	// combination 20/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -182,16 +256,16 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 13/128
-	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6:
+	// combination 21/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 14/128
-	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && i6:
+	// combination 22/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -199,8 +273,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 15/128
-	case !i0 && !i1 && !i2 && i3 && i4 && i5 && !i6:
+	// combination 23/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -208,8 +282,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 16/128
-	case !i0 && !i1 && !i2 && i3 && i4 && i5 && i6:
+	// combination 24/256
+	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -218,31 +292,107 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 17/128
-	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 25/256
+	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 26/256
+	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw}
+	// combination 27/256
+	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 28/256
+	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 29/256
+	case !i0 && !i1 && !i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 30/256
+	case !i0 && !i1 && !i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 31/256
+	case !i0 && !i1 && !i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 32/256
+	case !i0 && !i1 && !i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 33/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 		}{rw, rw, rw}
-	// combination 18/128
-	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6:
+	// combination 34/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 			http.Pusher
 		}{rw, rw, rw, rw}
-	// combination 19/128
-	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6:
+	// combination 35/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 20/128
-	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && i6:
+	// combination 36/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -250,16 +400,16 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 21/128
-	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6:
+	// combination 37/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 22/128
-	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && i6:
+	// combination 38/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -267,8 +417,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 23/128
-	case !i0 && !i1 && i2 && !i3 && i4 && i5 && !i6:
+	// combination 39/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -276,8 +426,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 24/128
-	case !i0 && !i1 && i2 && !i3 && i4 && i5 && i6:
+	// combination 40/256
+	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -286,16 +436,92 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 25/128
-	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6:
+	// combination 41/256
+	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 42/256
+	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw}
+	// combination 43/256
+	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 44/256
+	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 45/256
+	case !i0 && !i1 && i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 46/256
+	case !i0 && !i1 && i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 47/256
+	case !i0 && !i1 && i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 48/256
+	case !i0 && !i1 && i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 49/256
+	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw}
-	// combination 26/128
-	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && i6:
+	// combination 50/256
+	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -303,8 +529,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 27/128
-	case !i0 && !i1 && i2 && i3 && !i4 && i5 && !i6:
+	// combination 51/256
+	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -312,8 +538,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 28/128
-	case !i0 && !i1 && i2 && i3 && !i4 && i5 && i6:
+	// combination 52/256
+	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -322,8 +548,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 29/128
-	case !i0 && !i1 && i2 && i3 && i4 && !i5 && !i6:
+	// combination 53/256
+	case !i0 && !i1 && i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -331,8 +557,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 30/128
-	case !i0 && !i1 && i2 && i3 && i4 && !i5 && i6:
+	// combination 54/256
+	case !i0 && !i1 && i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -341,8 +567,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 31/128
-	case !i0 && !i1 && i2 && i3 && i4 && i5 && !i6:
+	// combination 55/256
+	case !i0 && !i1 && i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -351,8 +577,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 32/128
-	case !i0 && !i1 && i2 && i3 && i4 && i5 && i6:
+	// combination 56/256
+	case !i0 && !i1 && i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -362,31 +588,115 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 33/128
-	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 57/256
+	case !i0 && !i1 && i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 58/256
+	case !i0 && !i1 && i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 59/256
+	case !i0 && !i1 && i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 60/256
+	case !i0 && !i1 && i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 61/256
+	case !i0 && !i1 && i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 62/256
+	case !i0 && !i1 && i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 63/256
+	case !i0 && !i1 && i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 64/256
+	case !i0 && !i1 && i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 65/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 		}{rw, rw, rw}
-	// combination 34/128
-	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6:
+	// combination 66/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Pusher
 		}{rw, rw, rw, rw}
-	// combination 35/128
-	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6:
+	// combination 67/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 36/128
-	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && i6:
+	// combination 68/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -394,16 +704,16 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 37/128
-	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6:
+	// combination 69/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 38/128
-	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && i6:
+	// combination 70/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -411,8 +721,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 39/128
-	case !i0 && i1 && !i2 && !i3 && i4 && i5 && !i6:
+	// combination 71/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -420,8 +730,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 40/128
-	case !i0 && i1 && !i2 && !i3 && i4 && i5 && i6:
+	// combination 72/256
+	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -430,16 +740,92 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 41/128
-	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6:
+	// combination 73/256
+	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 74/256
+	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw}
+	// combination 75/256
+	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 76/256
+	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 77/256
+	case !i0 && i1 && !i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 78/256
+	case !i0 && i1 && !i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 79/256
+	case !i0 && i1 && !i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 80/256
+	case !i0 && i1 && !i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 81/256
+	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			io.ReaderFrom
 		}{rw, rw, rw, rw}
-	// combination 42/128
-	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && i6:
+	// combination 82/256
+	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -447,8 +833,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 43/128
-	case !i0 && i1 && !i2 && i3 && !i4 && i5 && !i6:
+	// combination 83/256
+	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -456,8 +842,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 44/128
-	case !i0 && i1 && !i2 && i3 && !i4 && i5 && i6:
+	// combination 84/256
+	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -466,8 +852,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 45/128
-	case !i0 && i1 && !i2 && i3 && i4 && !i5 && !i6:
+	// combination 85/256
+	case !i0 && i1 && !i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -475,8 +861,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 46/128
-	case !i0 && i1 && !i2 && i3 && i4 && !i5 && i6:
+	// combination 86/256
+	case !i0 && i1 && !i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -485,8 +871,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 47/128
-	case !i0 && i1 && !i2 && i3 && i4 && i5 && !i6:
+	// combination 87/256
+	case !i0 && i1 && !i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -495,8 +881,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 48/128
-	case !i0 && i1 && !i2 && i3 && i4 && i5 && i6:
+	// combination 88/256
+	case !i0 && i1 && !i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -506,16 +892,100 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 49/128
-	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 89/256
+	case !i0 && i1 && !i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 90/256
+	case !i0 && i1 && !i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 91/256
+	case !i0 && i1 && !i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 92/256
+	case !i0 && i1 && !i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 93/256
+	case !i0 && i1 && !i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 94/256
+	case !i0 && i1 && !i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 95/256
+	case !i0 && i1 && !i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 96/256
+	case !i0 && i1 && !i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 97/256
+	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
 		}{rw, rw, rw, rw}
-	// combination 50/128
-	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && i6:
+	// combination 98/256
+	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -523,8 +993,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 51/128
-	case !i0 && i1 && i2 && !i3 && !i4 && i5 && !i6:
+	// combination 99/256
+	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -532,8 +1002,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 52/128
-	case !i0 && i1 && i2 && !i3 && !i4 && i5 && i6:
+	// combination 100/256
+	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -542,8 +1012,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 53/128
-	case !i0 && i1 && i2 && !i3 && i4 && !i5 && !i6:
+	// combination 101/256
+	case !i0 && i1 && i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -551,8 +1021,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 54/128
-	case !i0 && i1 && i2 && !i3 && i4 && !i5 && i6:
+	// combination 102/256
+	case !i0 && i1 && i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -561,8 +1031,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 55/128
-	case !i0 && i1 && i2 && !i3 && i4 && i5 && !i6:
+	// combination 103/256
+	case !i0 && i1 && i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -571,8 +1041,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 56/128
-	case !i0 && i1 && i2 && !i3 && i4 && i5 && i6:
+	// combination 104/256
+	case !i0 && i1 && i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -582,8 +1052,92 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 57/128
-	case !i0 && i1 && i2 && i3 && !i4 && !i5 && !i6:
+	// combination 105/256
+	case !i0 && i1 && i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 106/256
+	case !i0 && i1 && i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 107/256
+	case !i0 && i1 && i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 108/256
+	case !i0 && i1 && i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 109/256
+	case !i0 && i1 && i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 110/256
+	case !i0 && i1 && i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 111/256
+	case !i0 && i1 && i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 112/256
+	case !i0 && i1 && i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 113/256
+	case !i0 && i1 && i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -591,8 +1145,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw}
-	// combination 58/128
-	case !i0 && i1 && i2 && i3 && !i4 && !i5 && i6:
+	// combination 114/256
+	case !i0 && i1 && i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -601,8 +1155,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 59/128
-	case !i0 && i1 && i2 && i3 && !i4 && i5 && !i6:
+	// combination 115/256
+	case !i0 && i1 && i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -611,8 +1165,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 60/128
-	case !i0 && i1 && i2 && i3 && !i4 && i5 && i6:
+	// combination 116/256
+	case !i0 && i1 && i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -622,8 +1176,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 61/128
-	case !i0 && i1 && i2 && i3 && i4 && !i5 && !i6:
+	// combination 117/256
+	case !i0 && i1 && i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -632,8 +1186,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 62/128
-	case !i0 && i1 && i2 && i3 && i4 && !i5 && i6:
+	// combination 118/256
+	case !i0 && i1 && i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -643,8 +1197,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 63/128
-	case !i0 && i1 && i2 && i3 && i4 && i5 && !i6:
+	// combination 119/256
+	case !i0 && i1 && i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -654,8 +1208,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 64/128
-	case !i0 && i1 && i2 && i3 && i4 && i5 && i6:
+	// combination 120/256
+	case !i0 && i1 && i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -666,31 +1220,123 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
-	// combination 65/128
-	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 121/256
+	case !i0 && i1 && i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 122/256
+	case !i0 && i1 && i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 123/256
+	case !i0 && i1 && i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 124/256
+	case !i0 && i1 && i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 125/256
+	case !i0 && i1 && i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 126/256
+	case !i0 && i1 && i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 127/256
+	case !i0 && i1 && i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 128/256
+	case !i0 && i1 && i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 129/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 		}{rw, rw, rw}
-	// combination 66/128
-	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6:
+	// combination 130/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			http.Pusher
 		}{rw, rw, rw, rw}
-	// combination 67/128
-	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6:
+	// combination 131/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 68/128
-	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6:
+	// combination 132/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -698,16 +1344,16 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 69/128
-	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6:
+	// combination 133/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 70/128
-	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6:
+	// combination 134/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -715,8 +1361,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 71/128
-	case i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6:
+	// combination 135/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -724,8 +1370,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 72/128
-	case i0 && !i1 && !i2 && !i3 && i4 && i5 && i6:
+	// combination 136/256
+	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -734,16 +1380,92 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 73/128
-	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6:
+	// combination 137/256
+	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 138/256
+	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw}
+	// combination 139/256
+	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 140/256
+	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 141/256
+	case i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 142/256
+	case i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 143/256
+	case i0 && !i1 && !i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 144/256
+	case i0 && !i1 && !i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 145/256
+	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			io.ReaderFrom
 		}{rw, rw, rw, rw}
-	// combination 74/128
-	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6:
+	// combination 146/256
+	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -751,8 +1473,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 75/128
-	case i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6:
+	// combination 147/256
+	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -760,8 +1482,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 76/128
-	case i0 && !i1 && !i2 && i3 && !i4 && i5 && i6:
+	// combination 148/256
+	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -770,8 +1492,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 77/128
-	case i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6:
+	// combination 149/256
+	case i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -779,8 +1501,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 78/128
-	case i0 && !i1 && !i2 && i3 && i4 && !i5 && i6:
+	// combination 150/256
+	case i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -789,8 +1511,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 79/128
-	case i0 && !i1 && !i2 && i3 && i4 && i5 && !i6:
+	// combination 151/256
+	case i0 && !i1 && !i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -799,8 +1521,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 80/128
-	case i0 && !i1 && !i2 && i3 && i4 && i5 && i6:
+	// combination 152/256
+	case i0 && !i1 && !i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -810,16 +1532,100 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 81/128
-	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 153/256
+	case i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 154/256
+	case i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 155/256
+	case i0 && !i1 && !i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 156/256
+	case i0 && !i1 && !i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 157/256
+	case i0 && !i1 && !i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 158/256
+	case i0 && !i1 && !i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 159/256
+	case i0 && !i1 && !i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 160/256
+	case i0 && !i1 && !i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 161/256
+	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
 		}{rw, rw, rw, rw}
-	// combination 82/128
-	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6:
+	// combination 162/256
+	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -827,8 +1633,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 83/128
-	case i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6:
+	// combination 163/256
+	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -836,8 +1642,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 84/128
-	case i0 && !i1 && i2 && !i3 && !i4 && i5 && i6:
+	// combination 164/256
+	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -846,8 +1652,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 85/128
-	case i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6:
+	// combination 165/256
+	case i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -855,8 +1661,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 86/128
-	case i0 && !i1 && i2 && !i3 && i4 && !i5 && i6:
+	// combination 166/256
+	case i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -865,8 +1671,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 87/128
-	case i0 && !i1 && i2 && !i3 && i4 && i5 && !i6:
+	// combination 167/256
+	case i0 && !i1 && i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -875,8 +1681,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 88/128
-	case i0 && !i1 && i2 && !i3 && i4 && i5 && i6:
+	// combination 168/256
+	case i0 && !i1 && i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -886,8 +1692,92 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 89/128
-	case i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6:
+	// combination 169/256
+	case i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 170/256
+	case i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 171/256
+	case i0 && !i1 && i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 172/256
+	case i0 && !i1 && i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 173/256
+	case i0 && !i1 && i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 174/256
+	case i0 && !i1 && i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 175/256
+	case i0 && !i1 && i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 176/256
+	case i0 && !i1 && i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 177/256
+	case i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -895,8 +1785,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw}
-	// combination 90/128
-	case i0 && !i1 && i2 && i3 && !i4 && !i5 && i6:
+	// combination 178/256
+	case i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -905,8 +1795,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 91/128
-	case i0 && !i1 && i2 && i3 && !i4 && i5 && !i6:
+	// combination 179/256
+	case i0 && !i1 && i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -915,8 +1805,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 92/128
-	case i0 && !i1 && i2 && i3 && !i4 && i5 && i6:
+	// combination 180/256
+	case i0 && !i1 && i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -926,8 +1816,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 93/128
-	case i0 && !i1 && i2 && i3 && i4 && !i5 && !i6:
+	// combination 181/256
+	case i0 && !i1 && i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -936,8 +1826,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 94/128
-	case i0 && !i1 && i2 && i3 && i4 && !i5 && i6:
+	// combination 182/256
+	case i0 && !i1 && i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -947,8 +1837,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 95/128
-	case i0 && !i1 && i2 && i3 && i4 && i5 && !i6:
+	// combination 183/256
+	case i0 && !i1 && i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -958,8 +1848,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 96/128
-	case i0 && !i1 && i2 && i3 && i4 && i5 && i6:
+	// combination 184/256
+	case i0 && !i1 && i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -970,16 +1860,108 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
-	// combination 97/128
-	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 185/256
+	case i0 && !i1 && i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 186/256
+	case i0 && !i1 && i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 187/256
+	case i0 && !i1 && i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 188/256
+	case i0 && !i1 && i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 189/256
+	case i0 && !i1 && i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 190/256
+	case i0 && !i1 && i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 191/256
+	case i0 && !i1 && i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 192/256
+	case i0 && !i1 && i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 193/256
+	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 		}{rw, rw, rw, rw}
-	// combination 98/128
-	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6:
+	// combination 194/256
+	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -987,8 +1969,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			http.Pusher
 		}{rw, rw, rw, rw, rw}
-	// combination 99/128
-	case i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6:
+	// combination 195/256
+	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -996,8 +1978,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 100/128
-	case i0 && i1 && !i2 && !i3 && !i4 && i5 && i6:
+	// combination 196/256
+	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1006,8 +1988,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 101/128
-	case i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6:
+	// combination 197/256
+	case i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1015,8 +1997,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 102/128
-	case i0 && i1 && !i2 && !i3 && i4 && !i5 && i6:
+	// combination 198/256
+	case i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1025,8 +2007,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 103/128
-	case i0 && i1 && !i2 && !i3 && i4 && i5 && !i6:
+	// combination 199/256
+	case i0 && i1 && !i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1035,8 +2017,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 104/128
-	case i0 && i1 && !i2 && !i3 && i4 && i5 && i6:
+	// combination 200/256
+	case i0 && i1 && !i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1046,8 +2028,92 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 105/128
-	case i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6:
+	// combination 201/256
+	case i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 202/256
+	case i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 203/256
+	case i0 && i1 && !i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 204/256
+	case i0 && i1 && !i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 205/256
+	case i0 && i1 && !i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 206/256
+	case i0 && i1 && !i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 207/256
+	case i0 && i1 && !i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 208/256
+	case i0 && i1 && !i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 209/256
+	case i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1055,8 +2121,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw}
-	// combination 106/128
-	case i0 && i1 && !i2 && i3 && !i4 && !i5 && i6:
+	// combination 210/256
+	case i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1065,8 +2131,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 107/128
-	case i0 && i1 && !i2 && i3 && !i4 && i5 && !i6:
+	// combination 211/256
+	case i0 && i1 && !i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1075,8 +2141,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 108/128
-	case i0 && i1 && !i2 && i3 && !i4 && i5 && i6:
+	// combination 212/256
+	case i0 && i1 && !i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1086,8 +2152,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 109/128
-	case i0 && i1 && !i2 && i3 && i4 && !i5 && !i6:
+	// combination 213/256
+	case i0 && i1 && !i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1096,8 +2162,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 110/128
-	case i0 && i1 && !i2 && i3 && i4 && !i5 && i6:
+	// combination 214/256
+	case i0 && i1 && !i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1107,8 +2173,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 111/128
-	case i0 && i1 && !i2 && i3 && i4 && i5 && !i6:
+	// combination 215/256
+	case i0 && i1 && !i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1118,8 +2184,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 112/128
-	case i0 && i1 && !i2 && i3 && i4 && i5 && i6:
+	// combination 216/256
+	case i0 && i1 && !i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1130,8 +2196,100 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
-	// combination 113/128
-	case i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6:
+	// combination 217/256
+	case i0 && i1 && !i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 218/256
+	case i0 && i1 && !i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 219/256
+	case i0 && i1 && !i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 220/256
+	case i0 && i1 && !i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 221/256
+	case i0 && i1 && !i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 222/256
+	case i0 && i1 && !i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 223/256
+	case i0 && i1 && !i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 224/256
+	case i0 && i1 && !i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 225/256
+	case i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1139,8 +2297,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			http.Hijacker
 		}{rw, rw, rw, rw, rw}
-	// combination 114/128
-	case i0 && i1 && i2 && !i3 && !i4 && !i5 && i6:
+	// combination 226/256
+	case i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1149,8 +2307,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 115/128
-	case i0 && i1 && i2 && !i3 && !i4 && i5 && !i6:
+	// combination 227/256
+	case i0 && i1 && i2 && !i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1159,8 +2317,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 116/128
-	case i0 && i1 && i2 && !i3 && !i4 && i5 && i6:
+	// combination 228/256
+	case i0 && i1 && i2 && !i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1170,8 +2328,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 117/128
-	case i0 && i1 && i2 && !i3 && i4 && !i5 && !i6:
+	// combination 229/256
+	case i0 && i1 && i2 && !i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1180,8 +2338,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 118/128
-	case i0 && i1 && i2 && !i3 && i4 && !i5 && i6:
+	// combination 230/256
+	case i0 && i1 && i2 && !i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1191,8 +2349,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 119/128
-	case i0 && i1 && i2 && !i3 && i4 && i5 && !i6:
+	// combination 231/256
+	case i0 && i1 && i2 && !i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1202,8 +2360,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 120/128
-	case i0 && i1 && i2 && !i3 && i4 && i5 && i6:
+	// combination 232/256
+	case i0 && i1 && i2 && !i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1214,8 +2372,100 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
-	// combination 121/128
-	case i0 && i1 && i2 && i3 && !i4 && !i5 && !i6:
+	// combination 233/256
+	case i0 && i1 && i2 && !i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 234/256
+	case i0 && i1 && i2 && !i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 235/256
+	case i0 && i1 && i2 && !i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 236/256
+	case i0 && i1 && i2 && !i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 237/256
+	case i0 && i1 && i2 && !i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 238/256
+	case i0 && i1 && i2 && !i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 239/256
+	case i0 && i1 && i2 && !i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 240/256
+	case i0 && i1 && i2 && !i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 241/256
+	case i0 && i1 && i2 && i3 && !i4 && !i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1224,8 +2474,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 122/128
-	case i0 && i1 && i2 && i3 && !i4 && !i5 && i6:
+	// combination 242/256
+	case i0 && i1 && i2 && i3 && !i4 && !i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1235,8 +2485,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 123/128
-	case i0 && i1 && i2 && i3 && !i4 && i5 && !i6:
+	// combination 243/256
+	case i0 && i1 && i2 && i3 && !i4 && !i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1246,8 +2496,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 124/128
-	case i0 && i1 && i2 && i3 && !i4 && i5 && i6:
+	// combination 244/256
+	case i0 && i1 && i2 && i3 && !i4 && !i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1258,8 +2508,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
-	// combination 125/128
-	case i0 && i1 && i2 && i3 && i4 && !i5 && !i6:
+	// combination 245/256
+	case i0 && i1 && i2 && i3 && !i4 && i5 && !i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1269,8 +2519,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 126/128
-	case i0 && i1 && i2 && i3 && i4 && !i5 && i6:
+	// combination 246/256
+	case i0 && i1 && i2 && i3 && !i4 && i5 && !i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1281,8 +2531,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
-	// combination 127/128
-	case i0 && i1 && i2 && i3 && i4 && i5 && !i6:
+	// combination 247/256
+	case i0 && i1 && i2 && i3 && !i4 && i5 && i6 && !i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1293,8 +2543,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
-	// combination 128/128
-	case i0 && i1 && i2 && i3 && i4 && i5 && i6:
+	// combination 248/256
+	case i0 && i1 && i2 && i3 && !i4 && i5 && i6 && i7:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -1306,6 +2556,106 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			fullDuplexEnabler
 			http.Pusher
 		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 249/256
+	case i0 && i1 && i2 && i3 && i4 && !i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 250/256
+	case i0 && i1 && i2 && i3 && i4 && !i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 251/256
+	case i0 && i1 && i2 && i3 && i4 && !i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 252/256
+	case i0 && i1 && i2 && i3 && i4 && !i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 253/256
+	case i0 && i1 && i2 && i3 && i4 && i5 && !i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 254/256
+	case i0 && i1 && i2 && i3 && i4 && i5 && !i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 255/256
+	case i0 && i1 && i2 && i3 && i4 && i5 && i6 && !i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 256/256
+	case i0 && i1 && i2 && i3 && i4 && i5 && i6 && i7:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw, rw}
 	}
 	panic("unreachable")
 }
@@ -1373,6 +2723,14 @@ func (w *rw) ReadFrom(src io.Reader) (int64, error) {
 		f = w.h.ReadFrom(f)
 	}
 	return f(src)
+}
+
+func (w *rw) FlushError() error {
+	f := w.w.(errorFlusher).FlushError
+	if w.h.FlushError != nil {
+		f = w.h.FlushError(f)
+	}
+	return f()
 }
 
 func (w *rw) SetReadDeadline(deadline time.Time) error {

--- a/wrap_generated_gteq_1.8_test.go
+++ b/wrap_generated_gteq_1.8_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWrap(t *testing.T) {
-	// combination 1/128
+	// combination 1/256
 	{
 		t.Log("http.ResponseWriter")
 		inner := struct {
@@ -34,6 +34,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -53,7 +56,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 2/128
+	// combination 2/256
 	{
 		t.Log("http.ResponseWriter, http.Pusher")
 		inner := struct {
@@ -76,6 +79,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -95,7 +101,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 3/128
+	// combination 3/256
 	{
 		t.Log("http.ResponseWriter, fullDuplexEnabler")
 		inner := struct {
@@ -118,6 +124,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -137,7 +146,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 4/128
+	// combination 4/256
 	{
 		t.Log("http.ResponseWriter, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -161,6 +170,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -180,7 +192,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 5/128
+	// combination 5/256
 	{
 		t.Log("http.ResponseWriter, deadliner")
 		inner := struct {
@@ -203,6 +215,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -222,7 +237,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 6/128
+	// combination 6/256
 	{
 		t.Log("http.ResponseWriter, deadliner, http.Pusher")
 		inner := struct {
@@ -246,6 +261,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -265,7 +283,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 7/128
+	// combination 7/256
 	{
 		t.Log("http.ResponseWriter, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -289,6 +307,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -308,7 +329,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 8/128
+	// combination 8/256
 	{
 		t.Log("http.ResponseWriter, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -333,6 +354,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -352,7 +376,379 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 9/128
+	// combination 9/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 10/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 11/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 12/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 13/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 14/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 15/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 16/256
+	{
+		t.Log("http.ResponseWriter, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 17/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom")
 		inner := struct {
@@ -375,6 +771,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -394,7 +793,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 10/128
+	// combination 18/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -418,6 +817,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -437,7 +839,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 11/128
+	// combination 19/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -461,6 +863,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -480,7 +885,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 12/128
+	// combination 20/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -505,6 +910,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -524,7 +932,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 13/128
+	// combination 21/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -548,6 +956,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -567,7 +978,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 14/128
+	// combination 22/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -592,6 +1003,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -611,7 +1025,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 15/128
+	// combination 23/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -636,6 +1050,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -655,7 +1072,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 16/128
+	// combination 24/256
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -681,6 +1098,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -700,7 +1120,387 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 17/128
+	// combination 25/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 26/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 27/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 28/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 29/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 30/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 31/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 32/256
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 33/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker")
 		inner := struct {
@@ -723,6 +1523,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -742,7 +1545,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 18/128
+	// combination 34/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, http.Pusher")
 		inner := struct {
@@ -766,6 +1569,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -785,7 +1591,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 19/128
+	// combination 35/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -809,6 +1615,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -828,7 +1637,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 20/128
+	// combination 36/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -853,6 +1662,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -872,7 +1684,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 21/128
+	// combination 37/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, deadliner")
 		inner := struct {
@@ -896,6 +1708,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -915,7 +1730,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 22/128
+	// combination 38/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, deadliner, http.Pusher")
 		inner := struct {
@@ -940,6 +1755,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -959,7 +1777,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 23/128
+	// combination 39/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -984,6 +1802,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1003,7 +1824,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 24/128
+	// combination 40/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -1029,6 +1850,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1048,7 +1872,387 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 25/128
+	// combination 41/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 42/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 43/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 44/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 45/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 46/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 47/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 48/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 49/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -1072,6 +2276,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1091,7 +2298,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 26/128
+	// combination 50/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -1116,6 +2323,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1135,7 +2345,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 27/128
+	// combination 51/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -1160,6 +2370,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1179,7 +2392,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 28/128
+	// combination 52/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -1205,6 +2418,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1224,7 +2440,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 29/128
+	// combination 53/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -1249,6 +2465,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1268,7 +2487,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 30/128
+	// combination 54/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -1294,6 +2513,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1313,7 +2535,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 31/128
+	// combination 55/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1339,6 +2561,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1358,7 +2583,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 32/128
+	// combination 56/256
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -1385,6 +2610,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1404,7 +2632,395 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 33/128
+	// combination 57/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 58/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 59/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 60/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 61/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 62/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 63/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 64/256
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 65/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier")
 		inner := struct {
@@ -1427,6 +3043,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1446,7 +3065,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 34/128
+	// combination 66/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Pusher")
 		inner := struct {
@@ -1470,6 +3089,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1489,7 +3111,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 35/128
+	// combination 67/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, fullDuplexEnabler")
 		inner := struct {
@@ -1513,6 +3135,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1532,7 +3157,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 36/128
+	// combination 68/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -1557,6 +3182,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1576,7 +3204,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 37/128
+	// combination 69/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, deadliner")
 		inner := struct {
@@ -1600,6 +3228,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1619,7 +3250,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 38/128
+	// combination 70/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, deadliner, http.Pusher")
 		inner := struct {
@@ -1644,6 +3275,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1663,7 +3297,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 39/128
+	// combination 71/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1688,6 +3322,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1707,7 +3344,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 40/128
+	// combination 72/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -1733,6 +3370,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1752,7 +3392,387 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 41/128
+	// combination 73/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 74/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 75/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 76/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 77/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 78/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 79/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 80/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 81/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom")
 		inner := struct {
@@ -1776,6 +3796,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1795,7 +3818,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 42/128
+	// combination 82/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -1820,6 +3843,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1839,7 +3865,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 43/128
+	// combination 83/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -1864,6 +3890,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1883,7 +3912,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 44/128
+	// combination 84/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -1909,6 +3938,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1928,7 +3960,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 45/128
+	// combination 85/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -1953,6 +3985,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1972,7 +4007,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 46/128
+	// combination 86/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -1998,6 +4033,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2017,7 +4055,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 47/128
+	// combination 87/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -2043,6 +4081,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2062,7 +4103,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 48/128
+	// combination 88/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -2089,6 +4130,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2108,7 +4152,395 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 49/128
+	// combination 89/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 90/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 91/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 92/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 93/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 94/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 95/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 96/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 97/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker")
 		inner := struct {
@@ -2132,6 +4564,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2151,7 +4586,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 50/128
+	// combination 98/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, http.Pusher")
 		inner := struct {
@@ -2176,6 +4611,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2195,7 +4633,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 51/128
+	// combination 99/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -2220,6 +4658,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2239,7 +4680,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 52/128
+	// combination 100/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -2265,6 +4706,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2284,7 +4728,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 53/128
+	// combination 101/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, deadliner")
 		inner := struct {
@@ -2309,6 +4753,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2328,7 +4775,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 54/128
+	// combination 102/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, deadliner, http.Pusher")
 		inner := struct {
@@ -2354,6 +4801,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2373,7 +4823,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 55/128
+	// combination 103/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -2399,6 +4849,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2418,7 +4871,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 56/128
+	// combination 104/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -2445,6 +4898,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2464,7 +4920,395 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 57/128
+	// combination 105/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 106/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 107/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 108/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 109/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 110/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 111/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 112/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 113/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -2489,6 +5333,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2508,7 +5355,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 58/128
+	// combination 114/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -2534,6 +5381,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2553,7 +5403,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 59/128
+	// combination 115/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -2579,6 +5429,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2598,7 +5451,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 60/128
+	// combination 116/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -2625,6 +5478,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2644,7 +5500,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 61/128
+	// combination 117/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -2670,6 +5526,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2689,7 +5548,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 62/128
+	// combination 118/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -2716,6 +5575,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2735,7 +5597,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 63/128
+	// combination 119/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -2762,6 +5624,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2781,7 +5646,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 64/128
+	// combination 120/256
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -2809,6 +5674,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2828,7 +5696,403 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 65/128
+	// combination 121/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 122/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 123/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 124/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 125/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 126/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 127/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 128/256
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 129/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher")
 		inner := struct {
@@ -2851,6 +6115,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2870,7 +6137,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 66/128
+	// combination 130/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Pusher")
 		inner := struct {
@@ -2894,6 +6161,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2913,7 +6183,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 67/128
+	// combination 131/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, fullDuplexEnabler")
 		inner := struct {
@@ -2937,6 +6207,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2956,7 +6229,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 68/128
+	// combination 132/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -2981,6 +6254,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3000,7 +6276,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 69/128
+	// combination 133/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, deadliner")
 		inner := struct {
@@ -3024,6 +6300,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3043,7 +6322,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 70/128
+	// combination 134/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, deadliner, http.Pusher")
 		inner := struct {
@@ -3068,6 +6347,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3087,7 +6369,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 71/128
+	// combination 135/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -3112,6 +6394,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3131,7 +6416,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 72/128
+	// combination 136/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -3157,6 +6442,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3176,7 +6464,387 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 73/128
+	// combination 137/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 138/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 139/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 140/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 141/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 142/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 143/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 144/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 145/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom")
 		inner := struct {
@@ -3200,6 +6868,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3219,7 +6890,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 74/128
+	// combination 146/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -3244,6 +6915,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3263,7 +6937,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 75/128
+	// combination 147/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -3288,6 +6962,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3307,7 +6984,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 76/128
+	// combination 148/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -3333,6 +7010,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3352,7 +7032,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 77/128
+	// combination 149/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -3377,6 +7057,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3396,7 +7079,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 78/128
+	// combination 150/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -3422,6 +7105,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3441,7 +7127,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 79/128
+	// combination 151/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -3467,6 +7153,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3486,7 +7175,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 80/128
+	// combination 152/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -3513,6 +7202,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3532,7 +7224,395 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 81/128
+	// combination 153/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 154/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 155/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 156/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 157/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 158/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 159/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 160/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 161/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker")
 		inner := struct {
@@ -3556,6 +7636,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3575,7 +7658,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 82/128
+	// combination 162/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, http.Pusher")
 		inner := struct {
@@ -3600,6 +7683,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3619,7 +7705,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 83/128
+	// combination 163/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -3644,6 +7730,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3663,7 +7752,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 84/128
+	// combination 164/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -3689,6 +7778,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3708,7 +7800,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 85/128
+	// combination 165/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, deadliner")
 		inner := struct {
@@ -3733,6 +7825,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3752,7 +7847,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 86/128
+	// combination 166/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, deadliner, http.Pusher")
 		inner := struct {
@@ -3778,6 +7873,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3797,7 +7895,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 87/128
+	// combination 167/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -3823,6 +7921,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3842,7 +7943,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 88/128
+	// combination 168/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -3869,6 +7970,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -3888,7 +7992,395 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 89/128
+	// combination 169/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 170/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 171/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 172/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 173/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 174/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 175/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 176/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 177/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -3913,6 +8405,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3932,7 +8427,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 90/128
+	// combination 178/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -3958,6 +8453,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -3977,7 +8475,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 91/128
+	// combination 179/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -4003,6 +8501,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4022,7 +8523,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 92/128
+	// combination 180/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -4049,6 +8550,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4068,7 +8572,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 93/128
+	// combination 181/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -4094,6 +8598,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4113,7 +8620,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 94/128
+	// combination 182/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -4140,6 +8647,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4159,7 +8669,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 95/128
+	// combination 183/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -4186,6 +8696,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4205,7 +8718,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 96/128
+	// combination 184/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -4233,6 +8746,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4252,7 +8768,403 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 97/128
+	// combination 185/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 186/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 187/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 188/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 189/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 190/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 191/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 192/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 193/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier")
 		inner := struct {
@@ -4276,6 +9188,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4295,7 +9210,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 98/128
+	// combination 194/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Pusher")
 		inner := struct {
@@ -4320,6 +9235,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4339,7 +9257,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 99/128
+	// combination 195/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, fullDuplexEnabler")
 		inner := struct {
@@ -4364,6 +9282,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4383,7 +9304,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 100/128
+	// combination 196/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -4409,6 +9330,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4428,7 +9352,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 101/128
+	// combination 197/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, deadliner")
 		inner := struct {
@@ -4453,6 +9377,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4472,7 +9399,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 102/128
+	// combination 198/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, deadliner, http.Pusher")
 		inner := struct {
@@ -4498,6 +9425,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4517,7 +9447,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 103/128
+	// combination 199/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -4543,6 +9473,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4562,7 +9495,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 104/128
+	// combination 200/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -4589,6 +9522,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4608,7 +9544,395 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 105/128
+	// combination 201/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 202/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 203/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 204/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 205/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 206/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 207/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 208/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 209/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom")
 		inner := struct {
@@ -4633,6 +9957,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4652,7 +9979,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 106/128
+	// combination 210/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -4678,6 +10005,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4697,7 +10027,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 107/128
+	// combination 211/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -4723,6 +10053,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4742,7 +10075,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 108/128
+	// combination 212/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -4769,6 +10102,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -4788,7 +10124,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 109/128
+	// combination 213/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -4814,6 +10150,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4833,7 +10172,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 110/128
+	// combination 214/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -4860,6 +10199,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4879,7 +10221,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 111/128
+	// combination 215/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -4906,6 +10248,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4925,7 +10270,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 112/128
+	// combination 216/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -4953,6 +10298,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -4972,7 +10320,403 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 113/128
+	// combination 217/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 218/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 219/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 220/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 221/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 222/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 223/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 224/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 225/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker")
 		inner := struct {
@@ -4997,6 +10741,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5016,7 +10763,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 114/128
+	// combination 226/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, http.Pusher")
 		inner := struct {
@@ -5042,6 +10789,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5061,7 +10811,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 115/128
+	// combination 227/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -5087,6 +10837,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5106,7 +10859,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 116/128
+	// combination 228/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -5133,6 +10886,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5152,7 +10908,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 117/128
+	// combination 229/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, deadliner")
 		inner := struct {
@@ -5178,6 +10934,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -5197,7 +10956,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 118/128
+	// combination 230/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, deadliner, http.Pusher")
 		inner := struct {
@@ -5224,6 +10983,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -5243,7 +11005,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 119/128
+	// combination 231/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -5270,6 +11032,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -5289,7 +11054,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 120/128
+	// combination 232/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -5317,6 +11082,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -5336,7 +11104,403 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 121/128
+	// combination 233/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 234/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 235/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 236/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 237/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 238/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 239/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 240/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 241/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -5362,6 +11526,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5381,7 +11548,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 122/128
+	// combination 242/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, http.Pusher")
 		inner := struct {
@@ -5408,6 +11575,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5427,7 +11597,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 123/128
+	// combination 243/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -5454,6 +11624,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5473,7 +11646,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 124/128
+	// combination 244/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -5501,6 +11674,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -5520,7 +11696,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 125/128
+	// combination 245/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -5547,6 +11723,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -5566,7 +11745,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 126/128
+	// combination 246/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, http.Pusher")
 		inner := struct {
@@ -5594,6 +11773,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -5613,7 +11795,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 127/128
+	// combination 247/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -5641,6 +11823,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -5660,7 +11845,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 128/128
+	// combination 248/256
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler, http.Pusher")
 		inner := struct {
@@ -5687,6 +11872,413 @@ func TestWrap(t *testing.T) {
 			t.Error("unexpected interface")
 		}
 		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 249/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 250/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 251/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 252/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 253/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 254/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 255/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Pusher); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 256/256
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler, http.Pusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+			http.Pusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
 			t.Error("unexpected interface")
 		}
 		if _, ok := w.(deadliner); ok != true {

--- a/wrap_generated_lt_1.8.go
+++ b/wrap_generated_lt_1.8.go
@@ -34,6 +34,9 @@ type HijackFunc func() (net.Conn, *bufio.ReadWriter, error)
 // ReadFromFunc is part of the io.ReaderFrom interface.
 type ReadFromFunc func(src io.Reader) (int64, error)
 
+// FlushErrorFunc is part of the errorFlusher interface.
+type FlushErrorFunc func() error
+
 // SetReadDeadlineFunc is part of the deadliner interface.
 type SetReadDeadlineFunc func(deadline time.Time) error
 
@@ -54,6 +57,7 @@ type Hooks struct {
 	CloseNotify      func(CloseNotifyFunc) CloseNotifyFunc
 	Hijack           func(HijackFunc) HijackFunc
 	ReadFrom         func(ReadFromFunc) ReadFromFunc
+	FlushError       func(FlushErrorFunc) FlushErrorFunc
 	SetReadDeadline  func(SetReadDeadlineFunc) SetReadDeadlineFunc
 	SetWriteDeadline func(SetWriteDeadlineFunc) SetWriteDeadlineFunc
 	EnableFullDuplex func(EnableFullDuplexFunc) EnableFullDuplexFunc
@@ -66,6 +70,7 @@ type Hooks struct {
 // - http.CloseNotifier
 // - http.Hijacker
 // - io.ReaderFrom
+// - errorFlusher
 // - deadliner
 // - fullDuplexEnabler
 //
@@ -81,62 +86,95 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 	_, i1 := w.(http.CloseNotifier)
 	_, i2 := w.(http.Hijacker)
 	_, i3 := w.(io.ReaderFrom)
-	_, i4 := w.(deadliner)
-	_, i5 := w.(fullDuplexEnabler)
+	_, i4 := w.(errorFlusher)
+	_, i5 := w.(deadliner)
+	_, i6 := w.(fullDuplexEnabler)
 	switch {
-	// combination 1/64
-	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5:
+	// combination 1/128
+	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 		}{rw, rw}
-	// combination 2/64
-	case !i0 && !i1 && !i2 && !i3 && !i4 && i5:
+	// combination 2/128
+	case !i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			fullDuplexEnabler
 		}{rw, rw, rw}
-	// combination 3/64
-	case !i0 && !i1 && !i2 && !i3 && i4 && !i5:
+	// combination 3/128
+	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			deadliner
 		}{rw, rw, rw}
-	// combination 4/64
-	case !i0 && !i1 && !i2 && !i3 && i4 && i5:
+	// combination 4/128
+	case !i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 5/64
-	case !i0 && !i1 && !i2 && i3 && !i4 && !i5:
+	// combination 5/128
+	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+		}{rw, rw, rw}
+	// combination 6/128
+	case !i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw}
+	// combination 7/128
+	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw}
+	// combination 8/128
+	case !i0 && !i1 && !i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 9/128
+	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			io.ReaderFrom
 		}{rw, rw, rw}
-	// combination 6/64
-	case !i0 && !i1 && !i2 && i3 && !i4 && i5:
+	// combination 10/128
+	case !i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 7/64
-	case !i0 && !i1 && !i2 && i3 && i4 && !i5:
+	// combination 11/128
+	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 8/64
-	case !i0 && !i1 && !i2 && i3 && i4 && i5:
+	// combination 12/128
+	case !i0 && !i1 && !i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -144,31 +182,67 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 9/64
-	case !i0 && !i1 && i2 && !i3 && !i4 && !i5:
+	// combination 13/128
+	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 14/128
+	case !i0 && !i1 && !i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 15/128
+	case !i0 && !i1 && !i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 16/128
+	case !i0 && !i1 && !i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 17/128
+	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 		}{rw, rw, rw}
-	// combination 10/64
-	case !i0 && !i1 && i2 && !i3 && !i4 && i5:
+	// combination 18/128
+	case !i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 11/64
-	case !i0 && !i1 && i2 && !i3 && i4 && !i5:
+	// combination 19/128
+	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 12/64
-	case !i0 && !i1 && i2 && !i3 && i4 && i5:
+	// combination 20/128
+	case !i0 && !i1 && i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -176,16 +250,52 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 13/64
-	case !i0 && !i1 && i2 && i3 && !i4 && !i5:
+	// combination 21/128
+	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 22/128
+	case !i0 && !i1 && i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 23/128
+	case !i0 && !i1 && i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 24/128
+	case !i0 && !i1 && i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 25/128
+	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw}
-	// combination 14/64
-	case !i0 && !i1 && i2 && i3 && !i4 && i5:
+	// combination 26/128
+	case !i0 && !i1 && i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -193,8 +303,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 15/64
-	case !i0 && !i1 && i2 && i3 && i4 && !i5:
+	// combination 27/128
+	case !i0 && !i1 && i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -202,8 +312,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 16/64
-	case !i0 && !i1 && i2 && i3 && i4 && i5:
+	// combination 28/128
+	case !i0 && !i1 && i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -212,31 +322,71 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 17/64
-	case !i0 && i1 && !i2 && !i3 && !i4 && !i5:
+	// combination 29/128
+	case !i0 && !i1 && i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 30/128
+	case !i0 && !i1 && i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 31/128
+	case !i0 && !i1 && i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 32/128
+	case !i0 && !i1 && i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 33/128
+	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 		}{rw, rw, rw}
-	// combination 18/64
-	case !i0 && i1 && !i2 && !i3 && !i4 && i5:
+	// combination 34/128
+	case !i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 19/64
-	case !i0 && i1 && !i2 && !i3 && i4 && !i5:
+	// combination 35/128
+	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 20/64
-	case !i0 && i1 && !i2 && !i3 && i4 && i5:
+	// combination 36/128
+	case !i0 && i1 && !i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -244,16 +394,52 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 21/64
-	case !i0 && i1 && !i2 && i3 && !i4 && !i5:
+	// combination 37/128
+	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 38/128
+	case !i0 && i1 && !i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 39/128
+	case !i0 && i1 && !i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 40/128
+	case !i0 && i1 && !i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 41/128
+	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			io.ReaderFrom
 		}{rw, rw, rw, rw}
-	// combination 22/64
-	case !i0 && i1 && !i2 && i3 && !i4 && i5:
+	// combination 42/128
+	case !i0 && i1 && !i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -261,8 +447,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 23/64
-	case !i0 && i1 && !i2 && i3 && i4 && !i5:
+	// combination 43/128
+	case !i0 && i1 && !i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -270,8 +456,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 24/64
-	case !i0 && i1 && !i2 && i3 && i4 && i5:
+	// combination 44/128
+	case !i0 && i1 && !i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -280,16 +466,56 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 25/64
-	case !i0 && i1 && i2 && !i3 && !i4 && !i5:
+	// combination 45/128
+	case !i0 && i1 && !i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 46/128
+	case !i0 && i1 && !i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 47/128
+	case !i0 && i1 && !i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 48/128
+	case !i0 && i1 && !i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 49/128
+	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.CloseNotifier
 			http.Hijacker
 		}{rw, rw, rw, rw}
-	// combination 26/64
-	case !i0 && i1 && i2 && !i3 && !i4 && i5:
+	// combination 50/128
+	case !i0 && i1 && i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -297,8 +523,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 27/64
-	case !i0 && i1 && i2 && !i3 && i4 && !i5:
+	// combination 51/128
+	case !i0 && i1 && i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -306,8 +532,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 28/64
-	case !i0 && i1 && i2 && !i3 && i4 && i5:
+	// combination 52/128
+	case !i0 && i1 && i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -316,8 +542,48 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 29/64
-	case !i0 && i1 && i2 && i3 && !i4 && !i5:
+	// combination 53/128
+	case !i0 && i1 && i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 54/128
+	case !i0 && i1 && i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 55/128
+	case !i0 && i1 && i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 56/128
+	case !i0 && i1 && i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 57/128
+	case !i0 && i1 && i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -325,8 +591,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw}
-	// combination 30/64
-	case !i0 && i1 && i2 && i3 && !i4 && i5:
+	// combination 58/128
+	case !i0 && i1 && i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -335,8 +601,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 31/64
-	case !i0 && i1 && i2 && i3 && i4 && !i5:
+	// combination 59/128
+	case !i0 && i1 && i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -345,8 +611,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 32/64
-	case !i0 && i1 && i2 && i3 && i4 && i5:
+	// combination 60/128
+	case !i0 && i1 && i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -356,31 +622,75 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 33/64
-	case i0 && !i1 && !i2 && !i3 && !i4 && !i5:
+	// combination 61/128
+	case !i0 && i1 && i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 62/128
+	case !i0 && i1 && i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 63/128
+	case !i0 && i1 && i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 64/128
+	case !i0 && i1 && i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 65/128
+	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 		}{rw, rw, rw}
-	// combination 34/64
-	case i0 && !i1 && !i2 && !i3 && !i4 && i5:
+	// combination 66/128
+	case i0 && !i1 && !i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			fullDuplexEnabler
 		}{rw, rw, rw, rw}
-	// combination 35/64
-	case i0 && !i1 && !i2 && !i3 && i4 && !i5:
+	// combination 67/128
+	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			deadliner
 		}{rw, rw, rw, rw}
-	// combination 36/64
-	case i0 && !i1 && !i2 && !i3 && i4 && i5:
+	// combination 68/128
+	case i0 && !i1 && !i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -388,16 +698,52 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 37/64
-	case i0 && !i1 && !i2 && i3 && !i4 && !i5:
+	// combination 69/128
+	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+		}{rw, rw, rw, rw}
+	// combination 70/128
+	case i0 && !i1 && !i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw}
+	// combination 71/128
+	case i0 && !i1 && !i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw}
+	// combination 72/128
+	case i0 && !i1 && !i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 73/128
+	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			io.ReaderFrom
 		}{rw, rw, rw, rw}
-	// combination 38/64
-	case i0 && !i1 && !i2 && i3 && !i4 && i5:
+	// combination 74/128
+	case i0 && !i1 && !i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -405,8 +751,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 39/64
-	case i0 && !i1 && !i2 && i3 && i4 && !i5:
+	// combination 75/128
+	case i0 && !i1 && !i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -414,8 +760,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 40/64
-	case i0 && !i1 && !i2 && i3 && i4 && i5:
+	// combination 76/128
+	case i0 && !i1 && !i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -424,16 +770,56 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 41/64
-	case i0 && !i1 && i2 && !i3 && !i4 && !i5:
+	// combination 77/128
+	case i0 && !i1 && !i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 78/128
+	case i0 && !i1 && !i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 79/128
+	case i0 && !i1 && !i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 80/128
+	case i0 && !i1 && !i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 81/128
+	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
 		}{rw, rw, rw, rw}
-	// combination 42/64
-	case i0 && !i1 && i2 && !i3 && !i4 && i5:
+	// combination 82/128
+	case i0 && !i1 && i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -441,8 +827,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 43/64
-	case i0 && !i1 && i2 && !i3 && i4 && !i5:
+	// combination 83/128
+	case i0 && !i1 && i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -450,8 +836,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 44/64
-	case i0 && !i1 && i2 && !i3 && i4 && i5:
+	// combination 84/128
+	case i0 && !i1 && i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -460,8 +846,48 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 45/64
-	case i0 && !i1 && i2 && i3 && !i4 && !i5:
+	// combination 85/128
+	case i0 && !i1 && i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 86/128
+	case i0 && !i1 && i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 87/128
+	case i0 && !i1 && i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 88/128
+	case i0 && !i1 && i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 89/128
+	case i0 && !i1 && i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -469,8 +895,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw}
-	// combination 46/64
-	case i0 && !i1 && i2 && i3 && !i4 && i5:
+	// combination 90/128
+	case i0 && !i1 && i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -479,8 +905,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 47/64
-	case i0 && !i1 && i2 && i3 && i4 && !i5:
+	// combination 91/128
+	case i0 && !i1 && i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -489,8 +915,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 48/64
-	case i0 && !i1 && i2 && i3 && i4 && i5:
+	// combination 92/128
+	case i0 && !i1 && i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -500,16 +926,60 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 49/64
-	case i0 && i1 && !i2 && !i3 && !i4 && !i5:
+	// combination 93/128
+	case i0 && !i1 && i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 94/128
+	case i0 && !i1 && i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 95/128
+	case i0 && !i1 && i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 96/128
+	case i0 && !i1 && i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 97/128
+	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
 			http.Flusher
 			http.CloseNotifier
 		}{rw, rw, rw, rw}
-	// combination 50/64
-	case i0 && i1 && !i2 && !i3 && !i4 && i5:
+	// combination 98/128
+	case i0 && i1 && !i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -517,8 +987,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw}
-	// combination 51/64
-	case i0 && i1 && !i2 && !i3 && i4 && !i5:
+	// combination 99/128
+	case i0 && i1 && !i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -526,8 +996,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			deadliner
 		}{rw, rw, rw, rw, rw}
-	// combination 52/64
-	case i0 && i1 && !i2 && !i3 && i4 && i5:
+	// combination 100/128
+	case i0 && i1 && !i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -536,8 +1006,48 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 53/64
-	case i0 && i1 && !i2 && i3 && !i4 && !i5:
+	// combination 101/128
+	case i0 && i1 && !i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+		}{rw, rw, rw, rw, rw}
+	// combination 102/128
+	case i0 && i1 && !i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 103/128
+	case i0 && i1 && !i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 104/128
+	case i0 && i1 && !i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 105/128
+	case i0 && i1 && !i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -545,8 +1055,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw}
-	// combination 54/64
-	case i0 && i1 && !i2 && i3 && !i4 && i5:
+	// combination 106/128
+	case i0 && i1 && !i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -555,8 +1065,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 55/64
-	case i0 && i1 && !i2 && i3 && i4 && !i5:
+	// combination 107/128
+	case i0 && i1 && !i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -565,8 +1075,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 56/64
-	case i0 && i1 && !i2 && i3 && i4 && i5:
+	// combination 108/128
+	case i0 && i1 && !i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -576,8 +1086,52 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 57/64
-	case i0 && i1 && i2 && !i3 && !i4 && !i5:
+	// combination 109/128
+	case i0 && i1 && !i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 110/128
+	case i0 && i1 && !i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 111/128
+	case i0 && i1 && !i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 112/128
+	case i0 && i1 && !i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 113/128
+	case i0 && i1 && i2 && !i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -585,8 +1139,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.CloseNotifier
 			http.Hijacker
 		}{rw, rw, rw, rw, rw}
-	// combination 58/64
-	case i0 && i1 && i2 && !i3 && !i4 && i5:
+	// combination 114/128
+	case i0 && i1 && i2 && !i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -595,8 +1149,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 59/64
-	case i0 && i1 && i2 && !i3 && i4 && !i5:
+	// combination 115/128
+	case i0 && i1 && i2 && !i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -605,8 +1159,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			deadliner
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 60/64
-	case i0 && i1 && i2 && !i3 && i4 && i5:
+	// combination 116/128
+	case i0 && i1 && i2 && !i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -616,8 +1170,52 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 61/64
-	case i0 && i1 && i2 && i3 && !i4 && !i5:
+	// combination 117/128
+	case i0 && i1 && i2 && !i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw}
+	// combination 118/128
+	case i0 && i1 && i2 && !i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 119/128
+	case i0 && i1 && i2 && !i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 120/128
+	case i0 && i1 && i2 && !i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 121/128
+	case i0 && i1 && i2 && i3 && !i4 && !i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -626,8 +1224,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			http.Hijacker
 			io.ReaderFrom
 		}{rw, rw, rw, rw, rw, rw}
-	// combination 62/64
-	case i0 && i1 && i2 && i3 && !i4 && i5:
+	// combination 122/128
+	case i0 && i1 && i2 && i3 && !i4 && !i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -637,8 +1235,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 63/64
-	case i0 && i1 && i2 && i3 && i4 && !i5:
+	// combination 123/128
+	case i0 && i1 && i2 && i3 && !i4 && i5 && !i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -648,8 +1246,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			io.ReaderFrom
 			deadliner
 		}{rw, rw, rw, rw, rw, rw, rw}
-	// combination 64/64
-	case i0 && i1 && i2 && i3 && i4 && i5:
+	// combination 124/128
+	case i0 && i1 && i2 && i3 && !i4 && i5 && i6:
 		return struct {
 			Unwrapper
 			http.ResponseWriter
@@ -660,6 +1258,54 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 			deadliner
 			fullDuplexEnabler
 		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 125/128
+	case i0 && i1 && i2 && i3 && i4 && !i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{rw, rw, rw, rw, rw, rw, rw}
+	// combination 126/128
+	case i0 && i1 && i2 && i3 && i4 && !i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 127/128
+	case i0 && i1 && i2 && i3 && i4 && i5 && !i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{rw, rw, rw, rw, rw, rw, rw, rw}
+	// combination 128/128
+	case i0 && i1 && i2 && i3 && i4 && i5 && i6:
+		return struct {
+			Unwrapper
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{rw, rw, rw, rw, rw, rw, rw, rw, rw}
 	}
 	panic("unreachable")
 }
@@ -727,6 +1373,14 @@ func (w *rw) ReadFrom(src io.Reader) (int64, error) {
 		f = w.h.ReadFrom(f)
 	}
 	return f(src)
+}
+
+func (w *rw) FlushError() error {
+	f := w.w.(errorFlusher).FlushError
+	if w.h.FlushError != nil {
+		f = w.h.FlushError(f)
+	}
+	return f()
 }
 
 func (w *rw) SetReadDeadline(deadline time.Time) error {

--- a/wrap_generated_lt_1.8_test.go
+++ b/wrap_generated_lt_1.8_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWrap(t *testing.T) {
-	// combination 1/64
+	// combination 1/128
 	{
 		t.Log("http.ResponseWriter")
 		inner := struct {
@@ -34,6 +34,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -50,7 +53,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 2/64
+	// combination 2/128
 	{
 		t.Log("http.ResponseWriter, fullDuplexEnabler")
 		inner := struct {
@@ -73,6 +76,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -89,7 +95,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 3/64
+	// combination 3/128
 	{
 		t.Log("http.ResponseWriter, deadliner")
 		inner := struct {
@@ -112,6 +118,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -128,7 +137,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 4/64
+	// combination 4/128
 	{
 		t.Log("http.ResponseWriter, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -152,6 +161,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -168,7 +180,179 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 5/64
+	// combination 5/128
+	{
+		t.Log("http.ResponseWriter, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 6/128
+	{
+		t.Log("http.ResponseWriter, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 7/128
+	{
+		t.Log("http.ResponseWriter, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 8/128
+	{
+		t.Log("http.ResponseWriter, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 9/128
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom")
 		inner := struct {
@@ -191,6 +375,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -207,7 +394,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 6/64
+	// combination 10/128
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -231,6 +418,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -247,7 +437,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 7/64
+	// combination 11/128
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -271,6 +461,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -287,7 +480,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 8/64
+	// combination 12/128
 	{
 		t.Log("http.ResponseWriter, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -312,6 +505,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -328,7 +524,183 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 9/64
+	// combination 13/128
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 14/128
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 15/128
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 16/128
+	{
+		t.Log("http.ResponseWriter, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 17/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker")
 		inner := struct {
@@ -351,6 +723,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -367,7 +742,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 10/64
+	// combination 18/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -391,6 +766,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -407,7 +785,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 11/64
+	// combination 19/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, deadliner")
 		inner := struct {
@@ -431,6 +809,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -447,7 +828,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 12/64
+	// combination 20/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -472,6 +853,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -488,7 +872,183 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 13/64
+	// combination 21/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 22/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 23/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 24/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 25/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -512,6 +1072,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -528,7 +1091,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 14/64
+	// combination 26/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -553,6 +1116,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -569,7 +1135,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 15/64
+	// combination 27/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -594,6 +1160,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -610,7 +1179,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 16/64
+	// combination 28/128
 	{
 		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -636,6 +1205,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -652,7 +1224,187 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 17/64
+	// combination 29/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 30/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 31/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 32/128
+	{
+		t.Log("http.ResponseWriter, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 33/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier")
 		inner := struct {
@@ -675,6 +1427,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -691,7 +1446,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 18/64
+	// combination 34/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, fullDuplexEnabler")
 		inner := struct {
@@ -715,6 +1470,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -731,7 +1489,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 19/64
+	// combination 35/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, deadliner")
 		inner := struct {
@@ -755,6 +1513,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -771,7 +1532,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 20/64
+	// combination 36/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -796,6 +1557,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -812,7 +1576,183 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 21/64
+	// combination 37/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 38/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 39/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 40/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 41/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom")
 		inner := struct {
@@ -836,6 +1776,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -852,7 +1795,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 22/64
+	// combination 42/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -877,6 +1820,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -893,7 +1839,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 23/64
+	// combination 43/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -918,6 +1864,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -934,7 +1883,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 24/64
+	// combination 44/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -960,6 +1909,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -976,7 +1928,187 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 25/64
+	// combination 45/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 46/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 47/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 48/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 49/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker")
 		inner := struct {
@@ -1000,6 +2132,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1016,7 +2151,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 26/64
+	// combination 50/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -1041,6 +2176,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1057,7 +2195,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 27/64
+	// combination 51/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, deadliner")
 		inner := struct {
@@ -1082,6 +2220,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1098,7 +2239,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 28/64
+	// combination 52/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1124,6 +2265,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1140,7 +2284,187 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 29/64
+	// combination 53/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 54/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 55/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 56/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 57/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -1165,6 +2489,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1181,7 +2508,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 30/64
+	// combination 58/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -1207,6 +2534,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1223,7 +2553,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 31/64
+	// combination 59/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -1249,6 +2579,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1265,7 +2598,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 32/64
+	// combination 60/128
 	{
 		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1292,6 +2625,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1308,7 +2644,191 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 33/64
+	// combination 61/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 62/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 63/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 64/128
+	{
+		t.Log("http.ResponseWriter, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 65/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher")
 		inner := struct {
@@ -1331,6 +2851,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1347,7 +2870,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 34/64
+	// combination 66/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, fullDuplexEnabler")
 		inner := struct {
@@ -1371,6 +2894,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1387,7 +2913,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 35/64
+	// combination 67/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, deadliner")
 		inner := struct {
@@ -1411,6 +2937,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1427,7 +2956,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 36/64
+	// combination 68/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1452,6 +2981,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1468,7 +3000,183 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 37/64
+	// combination 69/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 70/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 71/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 72/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 73/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom")
 		inner := struct {
@@ -1492,6 +3200,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1508,7 +3219,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 38/64
+	// combination 74/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -1533,6 +3244,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1549,7 +3263,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 39/64
+	// combination 75/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -1574,6 +3288,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1590,7 +3307,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 40/64
+	// combination 76/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1616,6 +3333,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1632,7 +3352,187 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 41/64
+	// combination 77/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 78/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 79/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 80/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 81/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker")
 		inner := struct {
@@ -1656,6 +3556,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1672,7 +3575,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 42/64
+	// combination 82/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -1697,6 +3600,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1713,7 +3619,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 43/64
+	// combination 83/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, deadliner")
 		inner := struct {
@@ -1738,6 +3644,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1754,7 +3663,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 44/64
+	// combination 84/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1780,6 +3689,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1796,7 +3708,187 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 45/64
+	// combination 85/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 86/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 87/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 88/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 89/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -1821,6 +3913,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1837,7 +3932,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 46/64
+	// combination 90/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -1863,6 +3958,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -1879,7 +3977,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 47/64
+	// combination 91/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -1905,6 +4003,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1921,7 +4022,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 48/64
+	// combination 92/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -1948,6 +4049,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -1964,7 +4068,191 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 49/64
+	// combination 93/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 94/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 95/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 96/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 97/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier")
 		inner := struct {
@@ -1988,6 +4276,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2004,7 +4295,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 50/64
+	// combination 98/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, fullDuplexEnabler")
 		inner := struct {
@@ -2029,6 +4320,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2045,7 +4339,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 51/64
+	// combination 99/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, deadliner")
 		inner := struct {
@@ -2070,6 +4364,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2086,7 +4383,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 52/64
+	// combination 100/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -2112,6 +4409,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2128,7 +4428,187 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 53/64
+	// combination 101/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 102/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 103/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 104/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 105/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom")
 		inner := struct {
@@ -2153,6 +4633,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2169,7 +4652,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 54/64
+	// combination 106/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -2195,6 +4678,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2211,7 +4697,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 55/64
+	// combination 107/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -2237,6 +4723,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2253,7 +4742,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 56/64
+	// combination 108/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -2280,6 +4769,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2296,7 +4788,191 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 57/64
+	// combination 109/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 110/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 111/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 112/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 113/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker")
 		inner := struct {
@@ -2321,6 +4997,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2337,7 +5016,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 58/64
+	// combination 114/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, fullDuplexEnabler")
 		inner := struct {
@@ -2363,6 +5042,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2379,7 +5061,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 59/64
+	// combination 115/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, deadliner")
 		inner := struct {
@@ -2405,6 +5087,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2421,7 +5106,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 60/64
+	// combination 116/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -2448,6 +5133,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != false {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2464,7 +5152,191 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 61/64
+	// combination 117/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 118/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 119/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 120/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 121/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom")
 		inner := struct {
@@ -2490,6 +5362,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2506,7 +5381,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 62/64
+	// combination 122/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, fullDuplexEnabler")
 		inner := struct {
@@ -2533,6 +5408,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != false {
 			t.Error("unexpected interface")
 		}
@@ -2549,7 +5427,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 63/64
+	// combination 123/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner")
 		inner := struct {
@@ -2576,6 +5454,9 @@ func TestWrap(t *testing.T) {
 		if _, ok := w.(io.ReaderFrom); ok != true {
 			t.Error("unexpected interface")
 		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
 		if _, ok := w.(deadliner); ok != true {
 			t.Error("unexpected interface")
 		}
@@ -2592,7 +5473,7 @@ func TestWrap(t *testing.T) {
 		}
 	}
 
-	// combination 64/64
+	// combination 124/128
 	{
 		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, deadliner, fullDuplexEnabler")
 		inner := struct {
@@ -2618,6 +5499,197 @@ func TestWrap(t *testing.T) {
 			t.Error("unexpected interface")
 		}
 		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 125/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 126/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != false {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != true {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 127/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(deadliner); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(fullDuplexEnabler); ok != false {
+			t.Error("unexpected interface")
+		}
+
+		if w, ok := w.(Unwrapper); ok {
+			if w.Unwrap() != inner {
+				t.Error("w.Unwrap() failed")
+			}
+		} else {
+			t.Error("Unwrapper interface not implemented")
+		}
+	}
+
+	// combination 128/128
+	{
+		t.Log("http.ResponseWriter, http.Flusher, http.CloseNotifier, http.Hijacker, io.ReaderFrom, errorFlusher, deadliner, fullDuplexEnabler")
+		inner := struct {
+			http.ResponseWriter
+			http.Flusher
+			http.CloseNotifier
+			http.Hijacker
+			io.ReaderFrom
+			errorFlusher
+			deadliner
+			fullDuplexEnabler
+		}{}
+		w := Wrap(inner, Hooks{})
+		if _, ok := w.(http.ResponseWriter); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Flusher); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.CloseNotifier); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(http.Hijacker); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(io.ReaderFrom); ok != true {
+			t.Error("unexpected interface")
+		}
+		if _, ok := w.(errorFlusher); ok != true {
 			t.Error("unexpected interface")
 		}
 		if _, ok := w.(deadliner); ok != true {


### PR DESCRIPTION
Introduced in https://github.com/golang/go/commit/fd0c0db4a41 (go1.20) along with net/http.ResponseController.

Example:

```go
package main

import (
	"fmt"
	"net/http"

	"github.com/felixge/httpsnoop"
)

type responseWriter struct {
	http.ResponseWriter
}

func (w *responseWriter) Flush() {
	fmt.Println("Flush called (but expected FlushError)")
}

func (w *responseWriter) FlushError() error {
	fmt.Println("FlushError called (as expected)")
	return fmt.Errorf("flush error (as expected)")
}

func main() {
	rw := httpsnoop.Wrap(&responseWriter{}, httpsnoop.Hooks{})
	rc := http.NewResponseController(rw)
	fmt.Println("Flush returned:", rc.Flush())
}
```

Expected output:
```
FlushError called (as expected)
Flush returned: flush error (as expected)
```

Actual output before this change:
```
Flush called (but expected FlushError)
Flush returned: <nil>
```