### PR TITLE
fix: preserve hooks for added writer interfaces

### DIFF
--- a/codegen/main.go
+++ b/codegen/main.go
@@ -81,9 +81,9 @@ func (b *Build) Implementation() *Generator {
 //     configured, WriteString calls the underlying WriteString method directly.
 //   - If the underlying ResponseWriter implements both http.Flusher and
 //     FlushError, and FlushError is called, but only the Flush hook is
-//     configured, FlushError is routed through the Flush hook and returns nil.
-//     If neither hook is configured, FlushError calls the underlying FlushError
-//     method directly.
+//     configured, FlushError is routed through the Flush hook while preserving
+//     the error returned by the underlying FlushError method. If neither hook is
+//     configured, FlushError calls the underlying FlushError method directly.
 type Hooks struct {
 `)
 	for _, iface := range ifaces {
@@ -134,7 +134,7 @@ type Hooks struct {
 				// http.ResponseController.Flush prefers FlushError over Flush.
 				// Preserve existing Flush hooks when wrapping writers that expose both.
 				g.Printf("} else if state.flush != nil {\n")
-				g.Printf("state.flushError = func() error { state.flush(); return nil }\n")
+				g.Printf("state.flushError = func() (err error) { hooks.Flush(func() { err = t%d.FlushError() })(); return err }\n", i)
 			} else if fn.Name == "WriteString" {
 				// io.WriteString prefers WriteString over Write. Preserve existing Write
 				// hooks when wrapping writers that expose both methods.

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -67,6 +67,23 @@ func (b *Build) Implementation() *Generator {
 // Hooks defines a set of method interceptors for methods included in
 // http.ResponseWriter as well as some others. You can think of them as
 // middleware for the function calls they target. See Wrap for more details.
+//
+// For each method, the exact matching hook takes precedence. For example,
+// WriteString calls the WriteString hook when it is configured, even if a
+// Write hook is also configured. If the exact hook is not configured, most
+// methods call through to the underlying ResponseWriter directly.
+//
+// Two compatibility fallbacks preserve the behavior users had before Wrap
+// learned about newer optional interfaces:
+//   - If the underlying ResponseWriter implements io.StringWriter and
+//     WriteString is called, but only the Write hook is configured, WriteString
+//     is routed through the Write hook with []byte(s). If neither hook is
+//     configured, WriteString calls the underlying WriteString method directly.
+//   - If the underlying ResponseWriter implements both http.Flusher and
+//     FlushError, and FlushError is called, but only the Flush hook is
+//     configured, FlushError is routed through the Flush hook and returns nil.
+//     If neither hook is configured, FlushError calls the underlying FlushError
+//     method directly.
 type Hooks struct {
 `)
 	for _, iface := range ifaces {
@@ -113,6 +130,17 @@ type Hooks struct {
 		for _, fn := range iface.Funcs {
 			g.Printf("if hooks.%s != nil {\n", fn.Name)
 			g.Printf("state.%s = hooks.%s(t%d.%s)\n", fieldName(fn.Name), fn.Name, i, fn.Name)
+			if fn.Name == "FlushError" {
+				// http.ResponseController.Flush prefers FlushError over Flush.
+				// Preserve existing Flush hooks when wrapping writers that expose both.
+				g.Printf("} else if state.flush != nil {\n")
+				g.Printf("state.flushError = func() error { state.flush(); return nil }\n")
+			} else if fn.Name == "WriteString" {
+				// io.WriteString prefers WriteString over Write. Preserve existing Write
+				// hooks when wrapping writers that expose both methods.
+				g.Printf("} else if state.write != nil {\n")
+				g.Printf("state.writeString = func(s string) (int, error) { return state.write([]byte(s)) }\n")
+			}
 			g.Printf("}\n")
 		}
 		g.Printf("}\n")

--- a/wrap_generated.go
+++ b/wrap_generated.go
@@ -52,6 +52,23 @@ type WriteStringFunc func(s string) (int, error)
 // Hooks defines a set of method interceptors for methods included in
 // http.ResponseWriter as well as some others. You can think of them as
 // middleware for the function calls they target. See Wrap for more details.
+//
+// For each method, the exact matching hook takes precedence. For example,
+// WriteString calls the WriteString hook when it is configured, even if a
+// Write hook is also configured. If the exact hook is not configured, most
+// methods call through to the underlying ResponseWriter directly.
+//
+// Two compatibility fallbacks preserve the behavior users had before Wrap
+// learned about newer optional interfaces:
+//   - If the underlying ResponseWriter implements io.StringWriter and
+//     WriteString is called, but only the Write hook is configured, WriteString
+//     is routed through the Write hook with []byte(s). If neither hook is
+//     configured, WriteString calls the underlying WriteString method directly.
+//   - If the underlying ResponseWriter implements both http.Flusher and
+//     FlushError, and FlushError is called, but only the Flush hook is
+//     configured, FlushError is routed through the Flush hook and returns nil.
+//     If neither hook is configured, FlushError calls the underlying FlushError
+//     method directly.
 type Hooks struct {
 	Header           func(HeaderFunc) HeaderFunc
 	WriteHeader      func(WriteHeaderFunc) WriteHeaderFunc
@@ -109,6 +126,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 		combo |= 1 << 7
 		if hooks.FlushError != nil {
 			state.flushError = hooks.FlushError(t1.FlushError)
+		} else if state.flush != nil {
+			state.flushError = func() error { state.flush(); return nil }
 		}
 	}
 	if t2, i2 := w.(http.CloseNotifier); i2 {
@@ -154,6 +173,8 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 		combo |= 1 << 0
 		if hooks.WriteString != nil {
 			state.writeString = hooks.WriteString(t8.WriteString)
+		} else if state.write != nil {
+			state.writeString = func(s string) (int, error) { return state.write([]byte(s)) }
 		}
 	}
 	switch combo {

--- a/wrap_generated.go
+++ b/wrap_generated.go
@@ -66,9 +66,9 @@ type WriteStringFunc func(s string) (int, error)
 //     configured, WriteString calls the underlying WriteString method directly.
 //   - If the underlying ResponseWriter implements both http.Flusher and
 //     FlushError, and FlushError is called, but only the Flush hook is
-//     configured, FlushError is routed through the Flush hook and returns nil.
-//     If neither hook is configured, FlushError calls the underlying FlushError
-//     method directly.
+//     configured, FlushError is routed through the Flush hook while preserving
+//     the error returned by the underlying FlushError method. If neither hook is
+//     configured, FlushError calls the underlying FlushError method directly.
 type Hooks struct {
 	Header           func(HeaderFunc) HeaderFunc
 	WriteHeader      func(WriteHeaderFunc) WriteHeaderFunc
@@ -127,7 +127,7 @@ func Wrap(w http.ResponseWriter, hooks Hooks) http.ResponseWriter {
 		if hooks.FlushError != nil {
 			state.flushError = hooks.FlushError(t1.FlushError)
 		} else if state.flush != nil {
-			state.flushError = func() error { state.flush(); return nil }
+			state.flushError = func() (err error) { hooks.Flush(func() { err = t1.FlushError() })(); return err }
 		}
 	}
 	if t2, i2 := w.(http.CloseNotifier); i2 {

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -2,6 +2,7 @@ package httpsnoop
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,7 +10,8 @@ import (
 )
 
 type flushErrorResponseWriter struct {
-	h http.Header
+	h   http.Header
+	err error
 }
 
 func (w *flushErrorResponseWriter) Header() http.Header {
@@ -22,7 +24,7 @@ func (w *flushErrorResponseWriter) Header() http.Header {
 func (w *flushErrorResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
 func (w *flushErrorResponseWriter) WriteHeader(code int)        {}
 func (w *flushErrorResponseWriter) Flush()                      {}
-func (w *flushErrorResponseWriter) FlushError() error           { return nil }
+func (w *flushErrorResponseWriter) FlushError() error           { return w.err }
 
 func TestWrap_preservesWriteHookForWriteString(t *testing.T) {
 	var got string
@@ -48,7 +50,8 @@ func TestWrap_preservesWriteHookForWriteString(t *testing.T) {
 
 func TestWrap_preservesFlushHookForFlushError(t *testing.T) {
 	flushed := false
-	w := Wrap(&flushErrorResponseWriter{}, Hooks{
+	wantErr := errors.New("flush failed")
+	w := Wrap(&flushErrorResponseWriter{err: wantErr}, Hooks{
 		Flush: func(next FlushFunc) FlushFunc {
 			return func() {
 				flushed = true
@@ -57,8 +60,8 @@ func TestWrap_preservesFlushHookForFlushError(t *testing.T) {
 		},
 	})
 
-	if err := http.NewResponseController(w).Flush(); err != nil {
-		t.Fatal(err)
+	if err := http.NewResponseController(w).Flush(); !errors.Is(err, wantErr) {
+		t.Fatalf("got err %v, want %v", err, wantErr)
 	}
 	if !flushed {
 		t.Fatal("Flush hook was not called")

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -8,6 +8,63 @@ import (
 	"testing"
 )
 
+type flushErrorResponseWriter struct {
+	h http.Header
+}
+
+func (w *flushErrorResponseWriter) Header() http.Header {
+	if w.h == nil {
+		w.h = http.Header{}
+	}
+	return w.h
+}
+
+func (w *flushErrorResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *flushErrorResponseWriter) WriteHeader(code int)        {}
+func (w *flushErrorResponseWriter) Flush()                      {}
+func (w *flushErrorResponseWriter) FlushError() error           { return nil }
+
+func TestWrap_preservesWriteHookForWriteString(t *testing.T) {
+	var got string
+	w := Wrap(httptest.NewRecorder(), Hooks{
+		Write: func(next WriteFunc) WriteFunc {
+			return func(p []byte) (int, error) {
+				got = string(p)
+				return next(p)
+			}
+		},
+	})
+
+	if _, ok := w.(io.StringWriter); !ok {
+		t.Fatal("wrapped writer should expose io.StringWriter")
+	}
+	if _, err := io.WriteString(w, "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Fatalf("Write hook saw %q, want %q", got, "hello")
+	}
+}
+
+func TestWrap_preservesFlushHookForFlushError(t *testing.T) {
+	flushed := false
+	w := Wrap(&flushErrorResponseWriter{}, Hooks{
+		Flush: func(next FlushFunc) FlushFunc {
+			return func() {
+				flushed = true
+				next()
+			}
+		},
+	})
+
+	if err := http.NewResponseController(w).Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if !flushed {
+		t.Fatal("Flush hook was not called")
+	}
+}
+
 func TestWrap_integration(t *testing.T) {
 	tests := []struct {
 		Name     string


### PR DESCRIPTION
Follow-up to #33.

#33 added support for `io.StringWriter` and `FlushError`, but those new interfaces changed method dispatch in ways that could bypass existing hooks:

- `io.WriteString` preferred `WriteString`, bypassing an existing `Hooks.Write` interceptor when no `Hooks.WriteString` was configured.
- `http.ResponseController.Flush` preferred `FlushError`, bypassing an existing `Hooks.Flush` interceptor when no `Hooks.FlushError` was configured.

This preserves the previous hook behavior by routing the new interface methods through the older hook when only the older hook is configured. For the `FlushError` fallback, the old `Flush` hook wraps the underlying `FlushError` call so the returned error is preserved.

## Hook behavior after this change

`Wrap(w, hooks)` still only exposes optional interfaces that `w` already exposes. Hooks do not add new capabilities.

General rule:

- For each method, the exact matching hook wins.
- If no exact hook is configured, most methods call the underlying method directly.
- The hook chain is prepared once during `Wrap`, not rebuilt on every method call.

Normal `http.ResponseWriter` methods:

| Call | If hook is configured | Otherwise |
| --- | --- | --- |
| `Header()` | `Hooks.Header` | `w.Header()` |
| `WriteHeader(code)` | `Hooks.WriteHeader` | `w.WriteHeader(code)` |
| `Write(p)` | `Hooks.Write` | `w.Write(p)` |

Optional methods follow the same exact-hook rule for `Flush`, `FlushError`, `CloseNotify`, `Hijack`, `ReadFrom`, `SetReadDeadline`, `SetWriteDeadline`, `EnableFullDuplex`, `Push`, and `WriteString`.

Compatibility fallback for `WriteString` when the underlying writer implements `io.StringWriter`:

| Hooks configured | `WriteString("x")` behavior |
| --- | --- |
| `WriteString` | Calls `Hooks.WriteString` |
| only `Write` | Calls `Hooks.Write` with `[]byte("x")` |
| both `Write` and `WriteString` | `WriteString` wins; `Write` is not called automatically |
| neither | Calls underlying `w.WriteString("x")` |

If the underlying writer does not implement `io.StringWriter`, the wrapper does not either, so `io.WriteString(wrapped, s)` falls back to `Write([]byte(s))` and `Hooks.Write` applies as before.

Compatibility fallback for `FlushError` when the underlying writer implements both `http.Flusher` and `FlushError`:

| Hooks configured | `FlushError()` / `ResponseController.Flush()` behavior |
| --- | --- |
| `FlushError` | Calls `Hooks.FlushError` |
| only `Flush` | Calls `Hooks.Flush`, whose `next` calls underlying `FlushError`; returns the underlying `FlushError` error |
| both `Flush` and `FlushError` | `FlushError` wins; `Flush` is not called automatically |
| neither | Calls underlying `FlushError()` |

If the underlying writer only implements `http.Flusher`, `ResponseController.Flush()` uses `Flush()`, so `Hooks.Flush` applies. If it only implements `FlushError`, `Hooks.Flush` cannot apply because there is no `Flush()` method to wrap; use `Hooks.FlushError`.

Tests added for both regressions, including preserving the underlying `FlushError` error through the `Flush` compatibility fallback.

Validation:

```sh
go test ./...
```
